### PR TITLE
Add BrightIdRegister to Subscriptions contract.

### DIFF
--- a/contracts/subscriptions/CourtSubscriptions.sol
+++ b/contracts/subscriptions/CourtSubscriptions.sol
@@ -158,6 +158,9 @@ contract CourtSubscriptions is ControlledRecoverable, TimeHelpers, RegisterAndCa
 
     /**
     * @dev The user just verified themselves in the BrightIdRegister, claim on there behalf.
+    * @param _usersSenderAddress The address from which the transaction was created
+    * @param _usersUniqueId The unique address assigned to the registered BrightId user
+    * @param _data Data used to determine what function to call, unused here
     */
     function receiveRegistration(address _usersSenderAddress, address _usersUniqueId, bytes calldata _data) external {
         require(msg.sender == address(_brightIdRegister()), ERROR_SENDER_NOT_BRIGHTID_REGISTER);

--- a/test/subscriptions/subscriptions-jurors.js
+++ b/test/subscriptions/subscriptions-jurors.js
@@ -180,7 +180,7 @@ contract('CourtSubscriptions', ([_, payer, jurorPeriod0Term1, jurorPeriod0Term1U
     })
   })
 
-  describe.only('receiveRegistration(address _usersSenderAddress, address _usersUniqueId, bytes _data)', () => {
+  describe('receiveRegistration(address _usersSenderAddress, address _usersUniqueId, bytes _data)', () => {
 
     it('registers and claims fess for initially unverified user', async () => {
       await activateJurors()
@@ -192,6 +192,8 @@ contract('CourtSubscriptions', ([_, payer, jurorPeriod0Term1, jurorPeriod0Term1U
       await brightIdHelper.registerUserWithData(jurorPeriod0Term3, subscriptions.address, '0x0')
 
       assert.isTrue(await subscriptions.hasJurorClaimed(jurorPeriod0Term3))
+      assert.isTrue(await brightIdRegister.isVerified(jurorPeriod0Term3))
+
     })
   })
 


### PR DESCRIPTION
We now check the claimer is verified and convert their address to their unique address to ensure they cannot claim from multiple accounts.

We also allow calling `claimFees()` through the BrightIdRegister `register()` function to remove the need to execute a separate transaction to register prior to calling `claimFees()` when the user needs to be verified.