### PR TITLE
Enable calling of functions that require verification through the BrightIdRegister

### DIFF
--- a/contracts/lib/BytesHelpers.sol
+++ b/contracts/lib/BytesHelpers.sol
@@ -27,7 +27,7 @@ library BytesHelpers {
 
     // See https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol for a more efficient but risky alternative
     function extractBytes(bytes memory _self, uint256 _from, uint256 _numberOfBytes) internal pure returns(bytes memory) {
-        if (_self.length < _from + _numberOfBytes) {
+        if (_self.length < _from + _numberOfBytes) { // No SafeMath as input is hardcoded
             return new bytes(0);
         }
 

--- a/contracts/lib/BytesHelpers.sol
+++ b/contracts/lib/BytesHelpers.sol
@@ -27,6 +27,10 @@ library BytesHelpers {
 
     // See https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol for a more efficient but risky alternative
     function extractBytes(bytes memory _self, uint256 _from, uint256 _numberOfBytes) internal pure returns(bytes memory) {
+        if (_self.length < _from + _numberOfBytes) {
+            return new bytes(0);
+        }
+
         bytes memory returnValue = new bytes(_numberOfBytes);
         for (uint256 i = _from; i < _from + _numberOfBytes; i++) {
             returnValue[i - _from] = _self[i];

--- a/contracts/lib/BytesHelpers.sol
+++ b/contracts/lib/BytesHelpers.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.8;
 
-
 library BytesHelpers {
     function toBytes4(bytes memory _self) internal pure returns (bytes4 result) {
         if (_self.length < 4) {
@@ -18,7 +17,12 @@ library BytesHelpers {
         assembly { result := mload(add(_self, _location)) }
     }
 
-    function toBytes(bytes memory _self, uint256 _location) internal pure returns (bytes memory result) {
-        assembly { result := mload(add(_self, _location)) }
+    // See https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol for a more efficient and risky alternative
+    function extractBytes(bytes memory _self, uint256 _from, uint256 _numberOfBytes) internal pure returns(bytes memory) {
+        bytes memory returnValue = new bytes(_numberOfBytes);
+        for (uint256 i = _from; i < _from + _numberOfBytes; i++) {
+            returnValue[i - _from] = _self[i];
+        }
+        return returnValue;
     }
 }

--- a/contracts/lib/BytesHelpers.sol
+++ b/contracts/lib/BytesHelpers.sol
@@ -10,14 +10,22 @@ library BytesHelpers {
     }
 
     function toUint256(bytes memory _self, uint256 _location) internal pure returns (uint256 result) {
-        if (_self.length < 32) {
+        if (_self.length < _location + 32) { // Location + uint256 length. No SafeMath as input is hardcoded
             return 0;
         }
-
-        assembly { result := mload(add(_self, _location)) }
+        uint256 realLocation = _location + 32; // Location + bytes array length
+        assembly { result := mload(add(_self, realLocation)) }
     }
 
-    // See https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol for a more efficient and risky alternative
+    function toBytes32(bytes memory _self, uint256 _location) internal pure returns (bytes32 result) {
+        if (_self.length < _location + 32) { // Location + bytes32 length. No SafeMath as input is hardcoded
+            return bytes32(0);
+        }
+        uint256 realLocation = _location + 32; // Location + bytes array length
+        assembly { result := mload(add(_self, realLocation)) }
+    }
+
+    // See https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol for a more efficient but risky alternative
     function extractBytes(bytes memory _self, uint256 _from, uint256 _numberOfBytes) internal pure returns(bytes memory) {
         bytes memory returnValue = new bytes(_numberOfBytes);
         for (uint256 i = _from; i < _from + _numberOfBytes; i++) {

--- a/contracts/lib/BytesHelpers.sol
+++ b/contracts/lib/BytesHelpers.sol
@@ -9,4 +9,16 @@ library BytesHelpers {
 
         assembly { result := mload(add(_self, 0x20)) }
     }
+
+    function toUint256(bytes memory _self, uint256 _location) internal pure returns (uint256 result) {
+        if (_self.length < 32) {
+            return 0;
+        }
+
+        assembly { result := mload(add(_self, _location)) }
+    }
+
+    function toBytes(bytes memory _self, uint256 _location) internal pure returns (bytes memory result) {
+        assembly { result := mload(add(_self, _location)) }
+    }
 }

--- a/contracts/registry/JurorsRegistry.sol
+++ b/contracts/registry/JurorsRegistry.sol
@@ -218,35 +218,21 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
     function receiveRegistration(address _jurorSenderAddress, address _jurorUniqueId, bytes calldata _data) external {
         require(msg.sender == address(_brightIdRegister()), ERROR_SENDER_NOT_BRIGHTID_REGISTER);
 
-        bytes memory dataMemory = _data;
-        bytes4 functionSelector = dataMemory.toBytes4();
-        uint256 amount = dataMemory.toUint256(36); // amountLocation: 32 + 4 = 36 (bytes array length + sig)
-        bytes memory callData = dataMemory.toBytes(48); // amountLocation: 32 + 4 + 32 = 48 (bytes array length + sig + uint256 _amount)
+        bytes4 functionSelector = _data.toBytes4();
+        uint256 amount = _data.toUint256(36); // amountLocation: 32 + 4 = 36 (bytes array length + sig)
 
         if (functionSelector == JurorsRegistry(this).activate.selector) {
-//            assembly {
-//                amount := mload(add(dataMemory, 36)) // amountLocation: 32 + 4 = 36 (bytes array length + sig)
-//            }
             _activateTokens(_jurorUniqueId, amount, _jurorSenderAddress);
 
         } else if (functionSelector == JurorsRegistry(this).deactivate.selector) {
-//            assembly {
-//                amount := mload(add(dataMemory, 36)) // amountLocation: 32 + 4 = 36 (bytes array length + sig)
-//            }
             _deactivateTokens(_jurorUniqueId, amount);
 
         } else if (functionSelector == JurorsRegistry(this).stake.selector) {
-//            assembly {
-//                amount := mload(add(dataMemory, 36)) // amountLocation: 32 + 4 = 36 (bytes array length + sig)
-//                callData := mload(add(dataMemory, 48)) // amountLocation: 32 + 4 + 32 = 48 (bytes array length + sig + uint256 _amount)
-//            }
+            bytes memory callData = _data.toBytes(48); // dataLocation: 32 + 4 + 32 = 48 (bytes array length + sig + uint256 _amount)
             _stake(_jurorSenderAddress, _jurorUniqueId, amount, callData);
 
         } else if (functionSelector == JurorsRegistry(this).unstake.selector) {
-//            assembly {
-//                amount := mload(add(dataMemory, 36)) // amountLocation: 32 + 4 = 36 (bytes array length + sig)
-//                callData := mload(add(dataMemory, 48)) // amountLocation: 32 + 4 + 32 = 48 (bytes array length + sig + uint256 _amount)
-//            }
+            bytes memory callData = _data.toBytes(48); // dataLocation: 32 + 4 + 32 = 48 (bytes array length + sig + uint256 _amount)
             _unstake(_jurorSenderAddress, _jurorUniqueId, amount, callData);
 
         } else {

--- a/contracts/registry/JurorsRegistry.sol
+++ b/contracts/registry/JurorsRegistry.sol
@@ -219,7 +219,7 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
         require(msg.sender == address(_brightIdRegister()), ERROR_SENDER_NOT_BRIGHTID_REGISTER);
 
         bytes4 functionSelector = _data.toBytes4();
-        uint256 amount = _data.toUint256(36); // amountLocation: 32 + 4 = 36 (bytes array length + sig)
+        uint256 amount = _data.toUint256(4); // amountLocation: 4 (from end of sig)
 
         if (functionSelector == JurorsRegistry(this).activate.selector) {
             _activateTokens(_jurorUniqueId, amount, _jurorSenderAddress);

--- a/contracts/registry/JurorsRegistry.sol
+++ b/contracts/registry/JurorsRegistry.sol
@@ -228,11 +228,11 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
             _deactivateTokens(_jurorUniqueId, amount);
 
         } else if (functionSelector == JurorsRegistry(this).stake.selector) {
-            bytes memory callData = _data.toBytes(48); // dataLocation: 32 + 4 + 32 = 48 (bytes array length + sig + uint256 _amount)
+            bytes memory callData = _data.extractBytes(100, 4); // callDataLocation: 4 + 32 + 32 + 32 = 100 (sig + uint256 _amount + callData location + callData length)
             _stake(_jurorSenderAddress, _jurorUniqueId, amount, callData);
 
         } else if (functionSelector == JurorsRegistry(this).unstake.selector) {
-            bytes memory callData = _data.toBytes(48); // dataLocation: 32 + 4 + 32 = 48 (bytes array length + sig + uint256 _amount)
+            bytes memory callData = _data.extractBytes(100, 4); // callDataLocation: 4 + 32 + 32 + 32 = 100 (sig + uint256 _amount + callData location + callData length)
             _unstake(_jurorSenderAddress, _jurorUniqueId, amount, callData);
 
         } else {

--- a/contracts/voting/CRVoting.sol
+++ b/contracts/voting/CRVoting.sol
@@ -22,6 +22,8 @@ contract CRVoting is Controlled, ICRVoting {
     string private constant ERROR_INVALID_COMMITMENT_SALT = "CRV_INVALID_COMMITMENT_SALT";
     string private constant ERROR_SENDER_NOT_VERIFIED = "CRV_SENDER_NOT_VERIFIED";
     string private constant ERROR_SENDER_NOT_BRIGHTID_REGISTER = "CRV_SENDER_NOT_BRIGHTID_REGISTER";
+    string private constant ERROR_NO_FUNCTION_MATCH = "CRV_NO_FUNCTION_MATCH";
+
 
     // Outcome nr. 0 is used to denote a missing vote (default)
     uint8 internal constant OUTCOME_MISSING = uint8(0);
@@ -150,10 +152,12 @@ contract CRVoting is Controlled, ICRVoting {
     function receiveRegistration(address _voterSenderAddress, address _voterUniqueId, bytes calldata _data) external {
         require(msg.sender == address(_brightIdRegister()), ERROR_SENDER_NOT_BRIGHTID_REGISTER);
 
-        if(_data.toBytes4() == CRVoting(this).commit.selector) {
+        if (_data.toBytes4() == CRVoting(this).commit.selector) {
             uint256 voteId = _data.toUint256(4); // voteIdLocation: 4 (from end of sig)
             bytes32 commitment = _data.toBytes32(36); // commitmentLocation: 4 + 32 = 36 (from end of sig + uint256 voteId)
             _commit(voteId, commitment, _voterUniqueId);
+        } else {
+            revert(ERROR_NO_FUNCTION_MATCH);
         }
     }
 

--- a/test/helpers/asserts/assertEvent.js
+++ b/test/helpers/asserts/assertEvent.js
@@ -1,8 +1,8 @@
-const { getEventAt, getEvents } = require('@aragon/test-helpers/events')
+const { getEventAt, getEvents } = require('@aragon/contract-helpers-test/src/events')
 const { isAddress, isBN, toChecksumAddress } = require('web3-utils')
 
-const assertEvent = (receipt, eventName, expectedArgs = {}, index = 0) => {
-  const event = getEventAt(receipt, eventName, index)
+const assertEvent = (receipt, eventName, expectedArgs = {}, index = 0, decodeForAbi) => {
+  const event = getEventAt(receipt, eventName, { index, decodeForAbi })
 
   assert(typeof event === 'object', `could not find an emitted ${eventName} event ${index === 0 ? '' : `at index ${index}`}`)
 
@@ -19,8 +19,8 @@ const assertEvent = (receipt, eventName, expectedArgs = {}, index = 0) => {
   }
 }
 
-const assertAmountOfEvents = (receipt, eventName, expectedAmount = 1) => {
-  const events = getEvents(receipt, eventName)
+const assertAmountOfEvents = (receipt, eventName, expectedAmount = 1, decodeForAbi) => {
+  const events = getEvents(receipt, eventName, { decodeForAbi })
   assert.equal(events.length, expectedAmount, `number of ${eventName} events does not match`)
 }
 

--- a/test/helpers/wrappers/brightid.js
+++ b/test/helpers/wrappers/brightid.js
@@ -41,7 +41,7 @@ module.exports = (web3, artifacts) => {
     }
 
     async registerUser(userUniqueAddress) {
-      await this.registerUserWithData(userUniqueAddress, ZERO_ADDRESS, '0x0')
+      await this.registerUserWithData([userUniqueAddress], ZERO_ADDRESS, '0x0')
     }
 
     async registerUsers(usersUniqueAddresses) {
@@ -50,11 +50,11 @@ module.exports = (web3, artifacts) => {
       }
     }
 
-    async registerUserWithData(userUniqueAddress, contractAddress, data) {
-      const addresses = [userUniqueAddress]
+    async registerUserWithData(userAddresses, contractAddress, data) {
+      const verifiedAddress = userAddresses[0]
       const timestamp = await this.brightIdRegister.getTimestampPublic()
-      const sig = this.getVerificationsSignature(addresses, timestamp)
-      await this.brightIdRegister.register(BRIGHT_ID_CONTEXT, addresses, timestamp, sig.v, sig.r, sig.s, contractAddress, data, { from: userUniqueAddress })
+      const sig = this.getVerificationsSignature(userAddresses, timestamp)
+      return await this.brightIdRegister.register(BRIGHT_ID_CONTEXT, userAddresses, timestamp, sig.v, sig.r, sig.s, contractAddress, data, { from: verifiedAddress })
     }
 
     async registerUserWithMultipleAddresses(userUniqueAddress, userSecondAddress) {

--- a/test/registry/jurors-registry-activation.js
+++ b/test/registry/jurors-registry-activation.js
@@ -216,7 +216,12 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
             const receipt = await registry.activate(requestedAmount, { from })
 
             assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED)
-            assertEvent(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED, { juror: jurorUniqueAddress, amount: deactivationAmount, availableTermId, processedTermId: termId })
+            assertEvent(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED, {
+              juror: jurorUniqueAddress,
+              amount: deactivationAmount,
+              availableTermId,
+              processedTermId: termId
+            })
           })
         }
       }
@@ -253,7 +258,7 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
           it('reverts', async () => {
             const amount = (await currentMaxActiveBalance()).add(amountAboveMax)
             await ANJ.approveAndCall(registry.address, amountAboveMax, '0x', { from })
-            await assertRevert(registry.activate(amount, { from }), "JR_ACTIVE_BALANCE_ABOVE_MAX")
+            await assertRevert(registry.activate(amount, { from }), 'JR_ACTIVE_BALANCE_ABOVE_MAX')
           })
         })
 
@@ -289,22 +294,19 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
           })
         })
 
-        context('when the juror calls activate through via BrightIdRegister', () => {
-          it.only('activates tokens as expected', async () => {
+        context('when the juror calls activate through the BrightIdRegister', () => {
+          it('activates tokens as expected', async () => {
             const activateAmount = MIN_ACTIVE_AMOUNT
-            await ANJ.generateTokens(juror2, activateAmount)
-            await ANJ.approveAndCall(registry.address, activateAmount, '0x', { from: juror2 })
             const activateFunctionData = registry.contract.methods.activate(activateAmount.toString()).encodeABI()
-            const { active: previousActiveBalance } = await registry.balanceOf(juror2)
-
+            const { active: previousActiveBalance } = await registry.balanceOf(juror)
             await brightIdHelper.expireVerifiedUsers()
-            assert.isFalse(await brightIdRegister.isVerified(juror2))
+            assert.isFalse(await brightIdRegister.isVerified(juror))
 
-            await brightIdHelper.registerUserWithData(juror2, registry.address, activateFunctionData)
+            await brightIdHelper.registerUserWithData([juror, jurorUniqueAddress], registry.address, activateFunctionData)
 
-            const { active: currentActiveBalance } = await registry.balanceOf(juror2)
+            const { active: currentActiveBalance } = await registry.balanceOf(juror)
             assertBn(currentActiveBalance, previousActiveBalance.add(activateAmount), 'Incorrect active balance')
-            assert.isTrue(await brightIdRegister.isVerified(juror2))
+            assert.isTrue(await brightIdRegister.isVerified(juror))
           })
         })
       })
@@ -361,7 +363,11 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
             context('when the given amount is zero', () => {
               const amount = bn(0)
 
-              itHandlesActivationProperlyFor({ requestedAmount: amount, deactivationAmount, expectDeactivationProcessed: true })
+              itHandlesActivationProperlyFor({
+                requestedAmount: amount,
+                deactivationAmount,
+                expectDeactivationProcessed: true
+              })
             })
 
             context('when the given amount is greater than the available balance', () => {
@@ -386,7 +392,7 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
                 it('reverts', async () => {
                   const amount = maxPossibleBalance.add(bn(1))
                   await ANJ.approveAndCall(registry.address, 1, '0x', { from })
-                  await assertRevert(registry.activate(amount, { from }), "JR_ACTIVE_BALANCE_ABOVE_MAX")
+                  await assertRevert(registry.activate(amount, { from }), 'JR_ACTIVE_BALANCE_ABOVE_MAX')
                 })
               })
             }
@@ -394,7 +400,11 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
             context('when the future active amount will be greater than the minimum active value', () => {
               const amount = MIN_ACTIVE_AMOUNT
 
-              itHandlesActivationProperlyFor({ requestedAmount: amount, deactivationAmount, expectDeactivationProcessed: true })
+              itHandlesActivationProperlyFor({
+                requestedAmount: amount,
+                deactivationAmount,
+                expectDeactivationProcessed: true
+              })
             })
           })
 
@@ -408,7 +418,11 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
             context('when the given amount is zero', () => {
               const amount = bn(0)
 
-              itHandlesActivationProperlyFor({ requestedAmount: amount, deactivationAmount, expectDeactivationProcessed: true })
+              itHandlesActivationProperlyFor({
+                requestedAmount: amount,
+                deactivationAmount,
+                expectDeactivationProcessed: true
+              })
             })
 
             context('when the given amount is greater than the available balance', () => {
@@ -433,7 +447,7 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
                 it('reverts', async () => {
                   const amount = maxPossibleBalance.add(bn(1))
                   await ANJ.approveAndCall(registry.address, 1, '0x', { from })
-                  await assertRevert(registry.activate(amount, { from }), "JR_ACTIVE_BALANCE_ABOVE_MAX")
+                  await assertRevert(registry.activate(amount, { from }), 'JR_ACTIVE_BALANCE_ABOVE_MAX')
                 })
               })
             }
@@ -441,7 +455,11 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
             context('when the future active amount will be greater than the minimum active value', () => {
               const amount = MIN_ACTIVE_AMOUNT
 
-              itHandlesActivationProperlyFor({ requestedAmount: amount, deactivationAmount, expectDeactivationProcessed: true })
+              itHandlesActivationProperlyFor({
+                requestedAmount: amount,
+                deactivationAmount,
+                expectDeactivationProcessed: true
+              })
             })
           })
         })
@@ -523,7 +541,7 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
             const amountToStake = TOTAL_ACTIVE_BALANCE_LIMIT.sub(maxPossibleBalance)
             await ANJ.approveAndCall(registry.address, amountToStake, '0x', { from })
 
-            await assertRevert(registry.activate(maxPossibleBalance, { from }), "JR_ACTIVE_BALANCE_ABOVE_MAX")
+            await assertRevert(registry.activate(maxPossibleBalance, { from }), 'JR_ACTIVE_BALANCE_ABOVE_MAX')
           })
         })
 
@@ -666,7 +684,11 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
             const receipt = await registry.deactivate(requestedAmount, { from })
 
             assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_REQUESTED)
-            assertEvent(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_REQUESTED, { juror: jurorUniqueAddress, availableTermId: termId.add(bn(1)), amount: expectedAmount })
+            assertEvent(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_REQUESTED, {
+              juror: jurorUniqueAddress,
+              availableTermId: termId.add(bn(1)),
+              amount: expectedAmount
+            })
           })
 
           it('can be requested at the next term', async () => {
@@ -695,7 +717,12 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
               const receipt = await registry.deactivate(requestedAmount, { from })
 
               assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED)
-              assertEvent(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED, { juror: jurorUniqueAddress, amount: previousDeactivationAmount, availableTermId, processedTermId: termId })
+              assertEvent(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED, {
+                juror: jurorUniqueAddress,
+                amount: previousDeactivationAmount,
+                availableTermId,
+                processedTermId: termId
+              })
             })
           }
         }
@@ -730,6 +757,21 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
           context('when the juror uses an unverified previous address', () => {
             it('reverts', async () => {
               await assertRevert(registry.deactivate(MIN_ACTIVE_AMOUNT, { from: jurorUniqueAddress }), 'JR_SENDER_NOT_VERIFIED')
+            })
+          })
+
+          context('when the juror calls deactivate through the BrightIdRegister', () => {
+            it('deactivates tokens as expected', async () => {
+              const deactivateFunctionData = registry.contract.methods.deactivate(activeBalance.toString()).encodeABI()
+              const { active: previousActiveBalance } = await registry.balanceOf(juror)
+              await brightIdHelper.expireVerifiedUsers()
+              assert.isFalse(await brightIdRegister.isVerified(juror))
+
+              await brightIdHelper.registerUserWithData([juror, jurorUniqueAddress], registry.address, deactivateFunctionData)
+
+              const { active: currentActiveBalance } = await registry.balanceOf(juror)
+              assertBn(currentActiveBalance, previousActiveBalance.sub(activeBalance), 'Incorrect active balance')
+              assert.isTrue(await brightIdRegister.isVerified(juror))
             })
           })
         })
@@ -897,8 +939,7 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
         await ANJ.approveAndCall(registry.address, jurorActiveBalance, ACTIVATE_DATA, { from: juror })
         const maxActiveBalanceAfterStake = await registry.maxActiveBalance(termId)
 
-        const juror2ActiveBalance = await maxActiveBalanceAtTerm(termId) // TODO: Test removing this. Should be the same as above check
-        await ANJ.approveAndCall(registry.address, juror2ActiveBalance, ACTIVATE_DATA, { from: juror2 })
+        await ANJ.approveAndCall(registry.address, jurorActiveBalance, ACTIVATE_DATA, { from: juror2 })
         assertBn(await registry.maxActiveBalance(termId), maxActiveBalanceAfterStake, 'Incorrect max active balance after stake')
 
         await controller.mockIncreaseTerm()
@@ -907,6 +948,30 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
       })
 
     })
+
+  })
+
+  describe('receive registration', () => {
+
+    context('when the caller is not the BrightIdRegister', () => {
+      it('reverts', async () => {
+        await assertRevert(registry.receiveRegistration(juror, jurorUniqueAddress, '0x0'), 'JR_SENDER_NOT_BRIGHTID_REGISTER')
+      })
+    })
+
+    context('when the data does not involve an available function', () => {
+      it('reverts', async () => {
+        await ANJ.generateTokens(juror, MIN_ACTIVE_AMOUNT)
+        await ANJ.approveAndCall(registry.address, MIN_ACTIVE_AMOUNT, '0x', { from: juror })
+        await registry.activate(MIN_ACTIVE_AMOUNT, { from: juror })
+
+        const incorrectFunctionData = registry.contract.methods.processDeactivationRequest(juror).encodeABI()
+
+        await assertRevert(brightIdHelper.registerUserWithData(
+          [juror, jurorUniqueAddress], registry.address, incorrectFunctionData), 'JR_NO_FUNCTION_MATCH')
+      })
+    })
+
 
   })
 })

--- a/test/registry/jurors-registry-activation.js
+++ b/test/registry/jurors-registry-activation.js
@@ -77,7 +77,7 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
     registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
     await controller.setJurorsRegistry(registry.address)
 
-    // Uncomment the below to test calling activate() and deactivate() via the BrightIdRegister
+    // Uncomment the below to test calling activate() and deactivate() via the BrightIdRegister. Note some tests are expected to fail
 
     // registry.activate = async (amount, { from }) => {
     //   console.log("Via BrightIdRegister")
@@ -101,11 +101,6 @@ contract('JurorsRegistry', ([_, juror, jurorUniqueAddress, juror2]) => {
 
   describe('activate', () => {
     const from = juror
-
-    const activateViaBrightIdRegister = async (activateAmount) => {
-      const activateFunctionData = registry.contract.methods.activate(activateAmount.toString()).encodeABI()
-      await brightIdHelper.registerUserWithData([juror, jurorUniqueAddress], registry.address, activateFunctionData)
-    }
 
     context('when the juror has not staked some tokens yet', () => {
       context('when the given amount is zero', () => {

--- a/test/registry/jurors-registry-staking.js
+++ b/test/registry/jurors-registry-staking.js
@@ -38,7 +38,7 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
     registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
     await controller.setJurorsRegistry(registry.address)
 
-    // Uncomment the below to test calling stake() and unstake() via the BrightIdRegister
+    // Uncomment the below to test calling stake() and unstake() via the BrightIdRegister. Note some tests are expected to fail
 
     // registry.stake = async (amount, data, { from }) => {
     //   console.log("Via BrightIdRegister")
@@ -1093,7 +1093,7 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
     })
   })
 
-  describe.only('unstake', () => {
+  describe('unstake', () => {
     const from = juror
     const data = '0xabcdef0123456789'
 

--- a/test/registry/jurors-registry-staking.js
+++ b/test/registry/jurors-registry-staking.js
@@ -37,6 +37,31 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
 
     registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
     await controller.setJurorsRegistry(registry.address)
+
+    // Uncomment the below to test calling stake() and unstake() via the BrightIdRegister
+
+    // registry.stake = async (amount, data, { from }) => {
+    //   console.log("Via BrightIdRegister")
+    //   const stakeFunctionData = registry.contract.methods.stake(amount.toString(), data).encodeABI()
+    //   if (from === juror) {
+    //     return await brightIdHelper.registerUserWithData([juror, jurorUniqueAddress], registry.address, stakeFunctionData)
+    //   } else if (from === juror2) {
+    //     return await brightIdHelper.registerUserWithData([juror2, juror2UniqueAddress], registry.address, stakeFunctionData)
+    //   } else {
+    //     return await brightIdHelper.registerUserWithData([from], registry.address, stakeFunctionData)
+    //   }
+    // }
+    // registry.unstake = async (amount, data, { from }) => {
+    //   console.log("Via BrightIdRegister")
+    //   const unstakeFunctionData = registry.contract.methods.unstake(amount.toString(), data).encodeABI()
+    //   if (from === juror) {
+    //     return await brightIdHelper.registerUserWithData([juror, jurorUniqueAddress], registry.address, unstakeFunctionData)
+    //   } else if (from === juror2) {
+    //     return await brightIdHelper.registerUserWithData([juror2, juror2UniqueAddress], registry.address, unstakeFunctionData)
+    //   } else {
+    //     return await brightIdHelper.registerUserWithData([from], registry.address, unstakeFunctionData)
+    //   }
+    // }
   })
 
   const registryDefinedUniqueUserId = async (address) => {
@@ -129,8 +154,9 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
 
             const receipt = await registry.stake(amount, data, { from })
 
-            assertAmountOfEvents(receipt, REGISTRY_EVENTS.STAKED)
-            assertEvent(receipt, REGISTRY_EVENTS.STAKED, { user: jurorUniqueAddress, amount, total: previousTotalStake.add(amount), data })
+            assertAmountOfEvents(receipt, REGISTRY_EVENTS.STAKED, 1, JurorsRegistry.abi)
+            assertEvent(receipt, REGISTRY_EVENTS.STAKED,
+              { user: jurorUniqueAddress, amount, total: previousTotalStake.add(amount), data }, 0, JurorsRegistry.abi)
           })
         })
 
@@ -273,8 +299,9 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
 
           const receipt = await registry.stake(amount, data, { from })
 
-          assertAmountOfEvents(receipt, REGISTRY_EVENTS.STAKED)
-          assertEvent(receipt, REGISTRY_EVENTS.STAKED, { user: jurorUniqueAddress, amount, total: previousTotalStake.add(amount), data })
+          assertAmountOfEvents(receipt, REGISTRY_EVENTS.STAKED, 1, JurorsRegistry.abi)
+          assertEvent(receipt, REGISTRY_EVENTS.STAKED,
+            { user: jurorUniqueAddress, amount, total: previousTotalStake.add(amount), data }, 0, JurorsRegistry.abi)
         })
 
         it('emits an activation event', async () => {
@@ -282,8 +309,9 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
 
           const receipt = await registry.stake(amount, data, { from })
 
-          assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_ACTIVATED)
-          assertEvent(receipt, REGISTRY_EVENTS.JUROR_ACTIVATED, { juror: jurorUniqueAddress, fromTermId: termId.add(bn(1)), amount, sender: from })
+          assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_ACTIVATED, 1, JurorsRegistry.abi)
+          assertEvent(receipt, REGISTRY_EVENTS.JUROR_ACTIVATED,
+            { juror: jurorUniqueAddress, fromTermId: termId.add(bn(1)), amount, sender: from }, 0, JurorsRegistry.abi)
         })
       }
 
@@ -487,8 +515,9 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
           const receipt = await registry.stakeFor(recipient, amount, data, { from })
 
           const uniqueUserId = await registryDefinedUniqueUserId(recipient)
-          assertAmountOfEvents(receipt, REGISTRY_EVENTS.STAKED)
-          assertEvent(receipt, REGISTRY_EVENTS.STAKED, { user: uniqueUserId, amount, total: previousTotalStake.add(amount), data })
+          assertAmountOfEvents(receipt, REGISTRY_EVENTS.STAKED, 1, JurorsRegistry.abi)
+          assertEvent(receipt, REGISTRY_EVENTS.STAKED,
+            { user: uniqueUserId, amount, total: previousTotalStake.add(amount), data }, 0, JurorsRegistry.abi)
         })
       })
 
@@ -666,8 +695,9 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
           const receipt = await registry.stakeFor(recipient, amount, data, { from })
 
           const uniqueUserId = await registryDefinedUniqueUserId(recipient)
-          assertAmountOfEvents(receipt, REGISTRY_EVENTS.STAKED)
-          assertEvent(receipt, REGISTRY_EVENTS.STAKED, { user: uniqueUserId, amount, total: previousTotalStake.add(amount), data })
+          assertAmountOfEvents(receipt, REGISTRY_EVENTS.STAKED, 1, JurorsRegistry.abi)
+          assertEvent(receipt, REGISTRY_EVENTS.STAKED,
+            { user: uniqueUserId, amount, total: previousTotalStake.add(amount), data }, 0, JurorsRegistry.abi)
         })
 
         it('emits an activation event', async () => {
@@ -676,8 +706,9 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
           const receipt = await registry.stakeFor(recipient, amount, data, { from })
 
           const uniqueUserId = await registryDefinedUniqueUserId(recipient)
-          assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_ACTIVATED)
-          assertEvent(receipt, REGISTRY_EVENTS.JUROR_ACTIVATED, { juror: uniqueUserId, fromTermId: termId.add(bn(1)), amount, sender: from })
+          assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_ACTIVATED, 1, JurorsRegistry.abi)
+          assertEvent(receipt, REGISTRY_EVENTS.JUROR_ACTIVATED,
+            { juror: uniqueUserId, fromTermId: termId.add(bn(1)), amount, sender: from }, 0, JurorsRegistry.abi)
         })
       }
 
@@ -1062,7 +1093,7 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
     })
   })
 
-  describe('unstake', () => {
+  describe.only('unstake', () => {
     const from = juror
     const data = '0xabcdef0123456789'
 
@@ -1164,8 +1195,9 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
 
           const receipt = await registry.unstake(amount, data, { from })
 
-          assertAmountOfEvents(receipt, REGISTRY_EVENTS.UNSTAKED)
-          assertEvent(receipt, REGISTRY_EVENTS.UNSTAKED, { user: jurorUniqueAddress, amount, total: previousTotalStake.sub(amount), data })
+          assertAmountOfEvents(receipt, REGISTRY_EVENTS.UNSTAKED, 1, JurorsRegistry.abi)
+          assertEvent(receipt, REGISTRY_EVENTS.UNSTAKED,
+            { user: jurorUniqueAddress, amount, total: previousTotalStake.sub(amount), data }, 0, JurorsRegistry.abi)
         })
 
         if (deactivationAmount.gt(bn(0))) {
@@ -1175,8 +1207,9 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorUniqueAddress, juror2UniqueA
 
             const receipt = await registry.unstake(amount, data, { from })
 
-            assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED)
-            assertEvent(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED, { juror: jurorUniqueAddress, amount: deactivationAmount, availableTermId, processedTermId: termId })
+            assertAmountOfEvents(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED, 1, JurorsRegistry.abi)
+            assertEvent(receipt, REGISTRY_EVENTS.JUROR_DEACTIVATION_PROCESSED,
+              { juror: jurorUniqueAddress, amount: deactivationAmount, availableTermId, processedTermId: termId }, 0, JurorsRegistry.abi)
           })
         }
       }

--- a/test/subscriptions/subscriptions-jurors.js
+++ b/test/subscriptions/subscriptions-jurors.js
@@ -189,7 +189,7 @@ contract('CourtSubscriptions', ([_, payer, jurorPeriod0Term1, jurorPeriod0Term1U
       assert.isFalse(await subscriptions.hasJurorClaimed(jurorPeriod0Term3))
       assert.isFalse(await brightIdRegister.isVerified(jurorPeriod0Term3))
 
-      await brightIdHelper.registerUserWithData(jurorPeriod0Term3, subscriptions.address, '0x0')
+      await brightIdHelper.registerUserWithData([jurorPeriod0Term3], subscriptions.address, '0x0')
 
       assert.isTrue(await subscriptions.hasJurorClaimed(jurorPeriod0Term3))
       assert.isTrue(await brightIdRegister.isVerified(jurorPeriod0Term3))

--- a/test/subscriptions/subscriptions-jurors.js
+++ b/test/subscriptions/subscriptions-jurors.js
@@ -193,7 +193,6 @@ contract('CourtSubscriptions', ([_, payer, jurorPeriod0Term1, jurorPeriod0Term1U
 
       assert.isTrue(await subscriptions.hasJurorClaimed(jurorPeriod0Term3))
       assert.isTrue(await brightIdRegister.isVerified(jurorPeriod0Term3))
-
     })
   })
 

--- a/test/voting/crvoting-commit.js
+++ b/test/voting/crvoting-commit.js
@@ -7,12 +7,13 @@ const { VOTING_EVENTS } = require('../helpers/utils/events')
 const { OUTCOMES, hashVote } = require('../helpers/utils/crvoting')
 const { DISPUTE_MANAGER_ERRORS, VOTING_ERRORS } = require('../helpers/utils/errors')
 const { assertEvent, assertAmountOfEvents } = require('../helpers/asserts/assertEvent')
+const CRVotingABI = require('../../abi/CRVoting.json')
 
 const CRVoting = artifacts.require('CRVoting')
 const DisputeManager = artifacts.require('DisputeManagerMockForVoting')
 
 contract('CRVoting', ([_, voter, voterUniqueAddress]) => {
-  let controller, voting, disputeManager
+  let controller, voting, disputeManager, brightIdHelper
 
   const POSSIBLE_OUTCOMES = 2
 
@@ -23,7 +24,7 @@ contract('CRVoting', ([_, voter, voterUniqueAddress]) => {
   })
 
   beforeEach('create voting module', async () => {
-    const brightIdHelper = buildBrightIdHelper()
+    brightIdHelper = buildBrightIdHelper()
     const brightIdRegister = await brightIdHelper.deploy()
     await brightIdHelper.registerUserWithMultipleAddresses(voterUniqueAddress, voter)
     await controller.setBrightIdRegister(brightIdRegister.address)
@@ -49,27 +50,42 @@ contract('CRVoting', ([_, voter, voterUniqueAddress]) => {
               await disputeManager.mockVoterWeight(voterUniqueAddress, weight)
             })
 
-            const itHandlesCommittedVotesFor = outcome => {
+            const submitCommitViaBrightIdRegister = async (voteId, commitment) => {
+              const commitFunctionData = voting.contract.methods.commit(voteId, commitment).encodeABI()
+              return await brightIdHelper.registerUserWithData(
+                [voter, voterUniqueAddress], voting.address, commitFunctionData)
+            }
+
+            const commitDirectOrBrightIdRegister = async (viaBrightIdRegister, voteId, commitment) => {
+              if (viaBrightIdRegister) {
+                return submitCommitViaBrightIdRegister(voteId, commitment)
+              } else {
+                return await voting.commit(voteId, commitment, { from: voter })
+              }
+            }
+
+            const itHandlesCommittedVotesFor = (outcome, viaBrightIdRegister) => {
               const commitment = hashVote(outcome)
 
               it('does not affect the voter outcome yet', async () => {
-                await voting.commit(voteId, commitment, { from: voter })
+                await commitDirectOrBrightIdRegister(viaBrightIdRegister, voteId, commitment)
 
                 const voterOutcome = await voting.getVoterOutcome(voteId, voter)
                 assertBn(voterOutcome, OUTCOMES.MISSING, 'voter outcome should be missing')
               })
 
               it('emits an event', async () => {
-                const receipt = await voting.commit(voteId, commitment, { from: voter })
+                const receipt = await commitDirectOrBrightIdRegister(viaBrightIdRegister, voteId, commitment)
 
-                assertAmountOfEvents(receipt, VOTING_EVENTS.VOTE_COMMITTED)
-                assertEvent(receipt, VOTING_EVENTS.VOTE_COMMITTED, { voteId, voter: voterUniqueAddress, commitment })
+                assertAmountOfEvents(receipt, VOTING_EVENTS.VOTE_COMMITTED, 1, CRVotingABI)
+                assertEvent(receipt, VOTING_EVENTS.VOTE_COMMITTED, { voteId, voter: voterUniqueAddress, commitment }, 0, CRVotingABI)
               })
+
 
               it('does not affect the outcomes tally', async () => {
                 const previousTally = await voting.getOutcomeTally(voteId, outcome)
 
-                await voting.commit(voteId, commitment, { from: voter })
+                await commitDirectOrBrightIdRegister(viaBrightIdRegister, voteId, commitment)
 
                 const currentTally = await voting.getOutcomeTally(voteId, outcome)
                 assertBn(previousTally, currentTally, 'tallies do not match')
@@ -79,7 +95,7 @@ contract('CRVoting', ([_, voter, voterUniqueAddress]) => {
                 const previousWinningOutcome = await voting.getWinningOutcome(voteId)
                 const previousWinningOutcomeTally = await voting.getOutcomeTally(voteId, previousWinningOutcome)
 
-                await voting.commit(voteId, commitment, { from: voter })
+                await commitDirectOrBrightIdRegister(viaBrightIdRegister, voteId, commitment)
 
                 const currentWinningOutcome = await voting.getWinningOutcome(voteId)
                 assertBn(previousWinningOutcome, currentWinningOutcome, 'winning outcomes do not match')
@@ -89,7 +105,7 @@ contract('CRVoting', ([_, voter, voterUniqueAddress]) => {
               })
 
               it('does not consider the voter a winner', async () => {
-                await voting.commit(voteId, commitment, { from: voter })
+                await commitDirectOrBrightIdRegister(viaBrightIdRegister, voteId, commitment)
 
                 const winningOutcome = await voting.getWinningOutcome(voteId)
                 assert.isFalse(await voting.hasVotedInFavorOf(voteId, winningOutcome, voter), 'voter should not be a winner')
@@ -98,22 +114,42 @@ contract('CRVoting', ([_, voter, voterUniqueAddress]) => {
 
             context('when the given commitment is equal to the missing outcome', async () => {
               itHandlesCommittedVotesFor(OUTCOMES.MISSING)
+
+              context('when called through the BrightIdRegister', async () => {
+                itHandlesCommittedVotesFor(OUTCOMES.MISSING, true)
+              })
             })
 
             context('when the given commitment is equal to the leaked outcome', async () => {
               itHandlesCommittedVotesFor(OUTCOMES.LEAKED)
+
+              context('when called through the BrightIdRegister', async () => {
+                itHandlesCommittedVotesFor(OUTCOMES.LEAKED, true)
+              })
             })
 
             context('when the given commitment is equal to the refused outcome', async () => {
               itHandlesCommittedVotesFor(OUTCOMES.REFUSED)
+
+              context('when called through the BrightIdRegister', async () => {
+                itHandlesCommittedVotesFor(OUTCOMES.REFUSED, true)
+              })
             })
 
             context('when the given commitment is a valid outcome', async () => {
               itHandlesCommittedVotesFor(OUTCOMES.LOW)
+
+              context('when called through the BrightIdRegister', async () => {
+                itHandlesCommittedVotesFor(OUTCOMES.LOW, true)
+              })
             })
 
             context('when the given commitment is an out-of-bounds outcome', async () => {
               itHandlesCommittedVotesFor(OUTCOMES.HIGH.add(bn(1)))
+
+              context('when called through the BrightIdRegister', async () => {
+                itHandlesCommittedVotesFor(OUTCOMES.HIGH.add(bn(1)), true)
+              })
             })
 
             context('when the sender is not verified', async () => {
@@ -174,6 +210,21 @@ contract('CRVoting', ([_, voter, voterUniqueAddress]) => {
     context('when the given vote ID is not valid', () => {
       it('reverts', async () => {
         await assertRevert(voting.commit(0, '0x', { from: voter }), VOTING_ERRORS.VOTE_DOES_NOT_EXIST)
+      })
+    })
+  })
+
+  describe('receiveRegistration', () => {
+    context('when not called from BrightIdRegister', () => {
+      it('reverts', async () => {
+        const voteId = 0
+        await disputeManager.create(voteId, POSSIBLE_OUTCOMES)
+        const weight = 10
+        await disputeManager.mockVoterWeight(voterUniqueAddress, weight)
+        const commitment = hashVote(OUTCOMES.LOW)
+        const commitFunctionData = voting.contract.methods.commit(voteId, commitment).encodeABI()
+
+        await assertRevert(voting.receiveRegistration(voter, voterUniqueAddress, commitFunctionData), "CRV_SENDER_NOT_BRIGHTID_REGISTER")
       })
     })
   })

--- a/test/voting/crvoting-commit.js
+++ b/test/voting/crvoting-commit.js
@@ -219,12 +219,23 @@ contract('CRVoting', ([_, voter, voterUniqueAddress]) => {
       it('reverts', async () => {
         const voteId = 0
         await disputeManager.create(voteId, POSSIBLE_OUTCOMES)
-        const weight = 10
-        await disputeManager.mockVoterWeight(voterUniqueAddress, weight)
+        await disputeManager.mockVoterWeight(voterUniqueAddress, 10)
         const commitment = hashVote(OUTCOMES.LOW)
         const commitFunctionData = voting.contract.methods.commit(voteId, commitment).encodeABI()
 
         await assertRevert(voting.receiveRegistration(voter, voterUniqueAddress, commitFunctionData), "CRV_SENDER_NOT_BRIGHTID_REGISTER")
+      })
+    })
+
+    context('when the data does not involve the commit function', () => {
+      it('reverts', async () => {
+        const voteId = 0
+        await disputeManager.create(voteId, POSSIBLE_OUTCOMES)
+        await disputeManager.mockVoterWeight(voterUniqueAddress, 10)
+        const commitFunctionData = voting.contract.methods.leak(0, voter, 0, '0x0').encodeABI()
+
+        await assertRevert(brightIdHelper.registerUserWithData(
+          [voter, voterUniqueAddress], voting.address, commitFunctionData), 'CRV_NO_FUNCTION_MATCH')
       })
     })
   })


### PR DESCRIPTION
Can now call all functions that require the calling account be verified through the BrightIdRegister to remove need to register with the BrightIdRegister in a separate transaction.