### PR TITLE
Added FeesUpdater contract for updating fees using stable coin value.

### DIFF
--- a/contracts/court/AragonCourt.sol
+++ b/contracts/court/AragonCourt.sol
@@ -24,7 +24,8 @@ contract AragonCourt is Controller, IArbitrator {
     * @param _governors Array containing:
     *        0. _fundsGovernor Address of the funds governor
     *        1. _configGovernor Address of the config governor
-    *        2. _modulesGovernor Address of the modules governor
+    *        2. _oracle Address of the price oracle
+    *        3. _modulesGovernor Address of the modules governor
     * @param _feeToken Address of the token contract that is used to pay for fees
     * @param _fees Array containing:
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
@@ -54,7 +55,7 @@ contract AragonCourt is Controller, IArbitrator {
     */
     constructor(
         uint64[2] memory _termParams,
-        address[3] memory _governors,
+        address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
         uint64[5] memory _roundStateDurations,

--- a/contracts/court/controller/Controller.sol
+++ b/contracts/court/controller/Controller.sol
@@ -71,7 +71,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     }
 
     /**
-    * @dev Ensure the msg.sender is the config governor or the price fees updater
+    * @dev Ensure the msg.sender is the config governor or the fees updater
     */
     modifier onlyConfigGovernorOrFeesUpdater {
         require(msg.sender == governor.config || msg.sender == governor.feesUpdater, ERROR_SENDER_NOT_GOVERNOR);

--- a/contracts/court/controller/Controller.sol
+++ b/contracts/court/controller/Controller.sol
@@ -38,6 +38,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     struct Governor {
         address funds;      // This address can be unset at any time. It is allowed to recover funds from the ControlledRecoverable modules
         address config;     // This address is meant not to be unset. It is allowed to change the different configurations of the whole system
+        address feesUpdater;// This is a second address that can update the config. It is expected to be used with a price oracle for updating fees
         address modules;    // This address can be unset at any time. It is allowed to plug/unplug modules from the system
     }
 
@@ -50,6 +51,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     event ModuleSet(bytes32 id, address addr);
     event FundsGovernorChanged(address previousGovernor, address currentGovernor);
     event ConfigGovernorChanged(address previousGovernor, address currentGovernor);
+    event FeesUpdaterChanged(address previousFeesUpdater, address currentFeesUpdater);
     event ModulesGovernorChanged(address previousGovernor, address currentGovernor);
 
     /**
@@ -61,10 +63,18 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     }
 
     /**
-    * @dev Ensure the msg.sender is the modules governor
+    * @dev Ensure the msg.sender is the config governor
     */
     modifier onlyConfigGovernor {
         require(msg.sender == governor.config, ERROR_SENDER_NOT_GOVERNOR);
+        _;
+    }
+
+    /**
+    * @dev Ensure the msg.sender is the config governor or the price fees updater
+    */
+    modifier onlyConfigGovernorOrFeesUpdater {
+        require(msg.sender == governor.config || msg.sender == governor.feesUpdater, ERROR_SENDER_NOT_GOVERNOR);
         _;
     }
 
@@ -84,7 +94,8 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     * @param _governors Array containing:
     *        0. _fundsGovernor Address of the funds governor
     *        1. _configGovernor Address of the config governor
-    *        2. _modulesGovernor Address of the modules governor
+    *        2. _feesUpdater Address of the price feesUpdater
+    *        3. _modulesGovernor Address of the modules governor
     * @param _feeToken Address of the token contract that is used to pay for fees
     * @param _fees Array containing:
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
@@ -114,7 +125,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     */
     constructor(
         uint64[2] memory _termParams,
-        address[3] memory _governors,
+        address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
         uint64[5] memory _roundStateDurations,
@@ -129,7 +140,8 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     {
         _setFundsGovernor(_governors[0]);
         _setConfigGovernor(_governors[1]);
-        _setModulesGovernor(_governors[2]);
+        _setFeesUpdater(_governors[2]);
+        _setModulesGovernor(_governors[3]);
     }
 
     /**
@@ -173,7 +185,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         uint256[3] calldata _jurorsParams
     )
         external
-        onlyConfigGovernor
+        onlyConfigGovernorOrFeesUpdater
     {
         uint64 currentTermId = _ensureCurrentTerm();
         _setConfig(
@@ -213,6 +225,14 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     function changeConfigGovernor(address _newConfigGovernor) external onlyConfigGovernor {
         require(_newConfigGovernor != ZERO_ADDRESS, ERROR_INVALID_GOVERNOR_ADDRESS);
         _setConfigGovernor(_newConfigGovernor);
+    }
+
+    /**
+    * @notice Change fees updater to `_newFeesUpdater`
+    * @param _newFeesUpdater Address of the new fees updater to be set
+    */
+    function changeFeesUpdater(address _newFeesUpdater) external onlyConfigGovernor {
+        _setFeesUpdater(_newFeesUpdater);
     }
 
     /**
@@ -346,6 +366,14 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     }
 
     /**
+    * @dev Tell the address of the fees updater
+    * @return Address of the fees updater
+    */
+    function getFeesUpdater() external view returns (address) {
+        return governor.feesUpdater;
+    }
+
+    /**
     * @dev Tell the address of the modules governor
     * @return Address of the modules governor
     */
@@ -426,6 +454,15 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     function _setConfigGovernor(address _newConfigGovernor) internal {
         emit ConfigGovernorChanged(governor.config, _newConfigGovernor);
         governor.config = _newConfigGovernor;
+    }
+
+    /**
+    * @dev Internal function to set the address of the fees updater
+    * @param _newFeesUpdater Address of the new fees updater to be set
+    */
+    function _setFeesUpdater(address _newFeesUpdater) internal {
+        emit FeesUpdaterChanged(governor.feesUpdater, _newFeesUpdater);
+        governor.feesUpdater = _newFeesUpdater;
     }
 
     /**

--- a/contracts/feesUpdater/FeesUpdater.sol
+++ b/contracts/feesUpdater/FeesUpdater.sol
@@ -1,0 +1,61 @@
+pragma solidity ^0.5.8;
+
+import "../court/AragonCourt.sol";
+import "./IPriceOracle.sol";
+import "../lib/os/ERC20.sol";
+
+contract FeesUpdater {
+
+    IPriceOracle public priceOracle;
+    AragonCourt public court;
+    address public courtFeeToken;
+    address public courtStableToken;
+    uint256[3] public courtStableValueFees;
+
+    constructor(
+        IPriceOracle _priceOracle,
+        AragonCourt _court,
+        address _courtFeeToken,
+        address _courtStableToken,
+        uint256[3] memory _courtStableValueFees
+    ) public {
+        priceOracle = _priceOracle;
+        court = _court;
+        courtFeeToken = _courtFeeToken;
+        courtStableToken = _courtStableToken;
+        courtStableValueFees = _courtStableValueFees;
+    }
+
+    function getStableFees() external view returns (uint256[3] memory) {
+        return courtStableValueFees;
+    }
+
+    /**
+    * @notice Convert the court fees from their stable value to the fee token value and update the court config from the
+    *   next term with them. This function can be called any number of times during a court term, the closer to the
+    *   start of the following term the more accurate the configured fees will be.
+    */
+    function updateCourtFees() external {
+        uint64 currentTerm = court.ensureCurrentTerm();
+
+        // We use the latest possible term to ensure that if the config has been updated by an account other
+        // than this oracle, the config fetched will be the updated one. However, this does mean that a config update
+        // that is scheduled for a future term will be scheduled for the next term instead.
+        uint64 latestPossibleTerm = uint64(-1);
+        (ERC20 feeToken,,
+        uint64[5] memory roundStateDurations,
+        uint16[2] memory pcts,
+        uint64[4] memory roundParams,
+        uint256[2] memory appealCollateralParams,
+        uint256[3] memory jurorsParams
+        ) = court.getConfig(latestPossibleTerm);
+
+        uint256[3] memory convertedFees;
+        convertedFees[0] = priceOracle.consult(courtStableToken, courtStableValueFees[0], courtFeeToken);
+        convertedFees[1] = priceOracle.consult(courtStableToken, courtStableValueFees[1], courtFeeToken);
+        convertedFees[2] = priceOracle.consult(courtStableToken, courtStableValueFees[2], courtFeeToken);
+
+        court.setConfig(currentTerm + 1, feeToken, convertedFees, roundStateDurations, pcts, roundParams,
+            appealCollateralParams, jurorsParams);
+    }
+}

--- a/contracts/feesUpdater/FeesUpdater.sol
+++ b/contracts/feesUpdater/FeesUpdater.sol
@@ -8,20 +8,17 @@ contract FeesUpdater {
 
     IPriceOracle public priceOracle;
     AragonCourt public court;
-    address public courtFeeToken;
     address public courtStableToken;
     uint256[3] public courtStableValueFees;
 
     constructor(
         IPriceOracle _priceOracle,
         AragonCourt _court,
-        address _courtFeeToken,
         address _courtStableToken,
         uint256[3] memory _courtStableValueFees
     ) public {
         priceOracle = _priceOracle;
         court = _court;
-        courtFeeToken = _courtFeeToken;
         courtStableToken = _courtStableToken;
         courtStableValueFees = _courtStableValueFees;
     }
@@ -51,9 +48,9 @@ contract FeesUpdater {
         ) = court.getConfig(latestPossibleTerm);
 
         uint256[3] memory convertedFees;
-        convertedFees[0] = priceOracle.consult(courtStableToken, courtStableValueFees[0], courtFeeToken);
-        convertedFees[1] = priceOracle.consult(courtStableToken, courtStableValueFees[1], courtFeeToken);
-        convertedFees[2] = priceOracle.consult(courtStableToken, courtStableValueFees[2], courtFeeToken);
+        convertedFees[0] = priceOracle.consult(courtStableToken, courtStableValueFees[0], address(feeToken));
+        convertedFees[1] = priceOracle.consult(courtStableToken, courtStableValueFees[1], address(feeToken));
+        convertedFees[2] = priceOracle.consult(courtStableToken, courtStableValueFees[2], address(feeToken));
 
         court.setConfig(currentTerm + 1, feeToken, convertedFees, roundStateDurations, pcts, roundParams,
             appealCollateralParams, jurorsParams);

--- a/contracts/feesUpdater/IPriceOracle.sol
+++ b/contracts/feesUpdater/IPriceOracle.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.5.8;
+
+contract IPriceOracle {
+    function consult(address tokenIn, uint256 amountIn, address tokenOut) external view returns (uint256 amountOut);
+}

--- a/contracts/test/court/AragonCourtMock.sol
+++ b/contracts/test/court/AragonCourtMock.sol
@@ -10,7 +10,7 @@ contract AragonCourtMock is AragonCourt, TimeHelpersMock {
 
     constructor(
         uint64[2] memory _termParams,
-        address[3] memory _governors,
+        address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
         uint64[5] memory _roundStateDurations,

--- a/contracts/test/feesUpdater/MockPriceOracle.sol
+++ b/contracts/test/feesUpdater/MockPriceOracle.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.8;
+
+import "../../feesUpdater/IPriceOracle.sol";
+
+contract MockPriceOracle is IPriceOracle {
+
+    uint256 public feeTokenPriceInStableToken;
+
+    constructor(uint256 _feeTokenPriceInStableToken) public {
+        feeTokenPriceInStableToken = _feeTokenPriceInStableToken;
+    }
+
+    function consult(address tokenIn, uint256 amountIn, address tokenOut) external view returns (uint256 amountOut) {
+        return amountIn / feeTokenPriceInStableToken;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:controller": "buidler test test/court/controller/*",
     "test:subscriptions": "buidler test test/subscriptions/*",
     "test:disputes": "buidler test test/disputes/*",
+    "test:feesupdater": "buidler test test/feesUpdater/*",
     "test:registry": "buidler test test/registry/*",
     "test:voting": "buidler test test/voting/*"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1hive/celeste",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Celeste Oracle",
   "author": "Aragon Association",
   "license": "GPL-3.0",

--- a/test/court/controller/controller-config.js
+++ b/test/court/controller/controller-config.js
@@ -8,7 +8,7 @@ const { assertConfig, buildNewConfig } = require('../../helpers/utils/config')(a
 const { assertEvent, assertAmountOfEvents } = require('../../helpers/asserts/assertEvent')
 const { CLOCK_ERRORS, CONFIG_ERRORS, CONTROLLER_ERRORS } = require('../../helpers/utils/errors')
 
-contract('Controller', ([_, configGovernor, someone, drafter, appealMaker, appealTaker, juror500, juror1000, juror3000]) => {
+contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appealMaker, appealTaker, juror500, juror1000, juror3000]) => {
   let courtHelper, controller
 
   let initialConfig, feeToken
@@ -154,7 +154,7 @@ contract('Controller', ([_, configGovernor, someone, drafter, appealMaker, appea
     let newConfig
 
     beforeEach('deploy controller and build new config', async () => {
-      controller = await courtHelper.deploy({ ...initialConfig, configGovernor })
+      controller = await courtHelper.deploy({ ...initialConfig, configGovernor, feesUpdater })
       newConfig = await buildNewConfig(initialConfig)
     })
 
@@ -441,6 +441,13 @@ contract('Controller', ([_, configGovernor, someone, drafter, appealMaker, appea
             await assertRevert(courtHelper.setConfig(configChangeTermId, newConfig, { from }), CONFIG_ERRORS.TOO_OLD_TERM)
           })
         })
+      })
+    })
+
+    context('when the sender is the fees updater', () => {
+      it('updates the config', async () => {
+        const receipt = await courtHelper.setConfig(0, newConfig, { from: feesUpdater })
+        assertAmountOfEvents(receipt, CONFIG_EVENTS.CONFIG_CHANGED)
       })
     })
 

--- a/test/feesUpdater/feesUpdater.js
+++ b/test/feesUpdater/feesUpdater.js
@@ -1,0 +1,133 @@
+const FeesUpdater = artifacts.require('FeesUpdater')
+const ERC20 = artifacts.require('ERC20Mock')
+const PriceOracle = artifacts.require('MockPriceOracle')
+const { bn, bigExp } = require('../helpers/lib/numbers')
+const { buildHelper } = require('../helpers/wrappers/court')(web3, artifacts)
+const { assertConfig, buildNewConfig } = require('../helpers/utils/config')(artifacts)
+const { assertBn } = require('../helpers/asserts/assertBn')
+
+const FEE_TOKEN_PRICE_IN_STABLE_TOKEN = bn(500);
+
+contract("FeesUpdater", ([_]) => {
+  let courtHelper, controller, feesUpdater, priceOracle, feeToken, stableToken, initialConfig
+
+  const jurorFee = bigExp(10, 18)
+  const draftFee = bigExp(30, 18)
+  const settleFee = bigExp(40, 18)
+  const evidenceTerms = bn(1)
+  const commitTerms = bn(1)
+  const revealTerms = bn(2)
+  const appealTerms = bn(3)
+  const appealConfirmTerms = bn(4)
+  const penaltyPct = bn(100)
+  const finalRoundReduction = bn(3300)
+  const firstRoundJurorsNumber = bn(5)
+  const appealStepFactor = bn(3)
+  const maxRegularAppealRounds = bn(2)
+  const finalRoundLockTerms = bn(2)
+  const appealCollateralFactor = bn(4)
+  const appealConfirmCollateralFactor = bn(6)
+  const minActiveBalance = bigExp(200, 18)
+  const minMaxPctTotalSupply = bigExp(2, 15) // 0.2%
+  const maxMaxPctTotalSupply = bigExp(2, 16) // 2%
+
+  const stableFees = [jurorFee, draftFee, settleFee]
+  const feeTokenJurorFee = jurorFee.div(FEE_TOKEN_PRICE_IN_STABLE_TOKEN)
+  const feeTokenDraftFee = draftFee.div(FEE_TOKEN_PRICE_IN_STABLE_TOKEN)
+  const feeTokenSettleFee = settleFee.div(FEE_TOKEN_PRICE_IN_STABLE_TOKEN)
+
+  const checkConfig = async (termId, expectedConfig) => assertConfig(await courtHelper.getConfig(termId), expectedConfig)
+
+  const assertBnDeepEqual = (actualArray, expectedArray, errorMessage) => {
+    for (let i = 0; i < actualArray.length; i++) {
+        assertBn(actualArray[i], expectedArray[i], errorMessage)
+    }
+  }
+
+  beforeEach('create helper', async () => {
+    priceOracle = await PriceOracle.new(FEE_TOKEN_PRICE_IN_STABLE_TOKEN)
+    feeToken = await ERC20.new('Court Fee Token', 'CFT', 18)
+    stableToken = await ERC20.new('Court Stable Token', 'DAI', 18)
+    initialConfig = {
+      feeToken,
+      jurorFee,
+      draftFee,
+      settleFee,
+      evidenceTerms,
+      commitTerms,
+      revealTerms,
+      appealTerms,
+      appealConfirmTerms,
+      penaltyPct,
+      finalRoundReduction,
+      firstRoundJurorsNumber,
+      appealStepFactor,
+      maxRegularAppealRounds,
+      finalRoundLockTerms,
+      appealCollateralFactor,
+      appealConfirmCollateralFactor,
+      minActiveBalance,
+      minMaxPctTotalSupply,
+      maxMaxPctTotalSupply
+    }
+    courtHelper = buildHelper()
+    controller = await courtHelper.deploy({ ...initialConfig })
+
+    feesUpdater = await FeesUpdater.new(priceOracle.address, controller.address, feeToken.address, stableToken.address, stableFees)
+    await controller.changeFeesUpdater(feesUpdater.address)
+  })
+
+  it('stores constructor params', async () => {
+    assert.equal(await feesUpdater.priceOracle(), priceOracle.address, 'Incorrect price oracle')
+    assert.equal(await feesUpdater.court(), controller.address, 'Incorrect court address')
+    assert.equal(await feesUpdater.courtFeeToken(), feeToken.address, 'Incorrect fee token')
+    assert.equal(await feesUpdater.courtStableToken(), stableToken.address, 'Incorrect stable token')
+    assertBnDeepEqual(await feesUpdater.getStableFees(), stableFees, 'Incorrect stable fees')
+  })
+
+  context('updateCourtFees()', () => {
+    it('updates fees for next term leaving current params the same', async () => {
+      await feesUpdater.updateCourtFees();
+
+      const newConfig = { ...initialConfig,
+        jurorFee: feeTokenJurorFee,
+        draftFee: feeTokenDraftFee,
+        settleFee: feeTokenSettleFee
+      }
+      await checkConfig(1, newConfig)
+    })
+
+    it('if config is due to change, it uses that config instead of the current config', async () => {
+      const futureTermId = 100
+      const newConfig = await buildNewConfig(initialConfig)
+      await courtHelper.setConfig(futureTermId, newConfig)
+      await checkConfig(99, initialConfig)
+      await checkConfig(100, newConfig)
+
+      await feesUpdater.updateCourtFees();
+
+      const configAfterUpdate = { ...newConfig,
+        jurorFee: feeTokenJurorFee,
+        draftFee: feeTokenDraftFee,
+        settleFee: feeTokenSettleFee
+      }
+      await checkConfig(1, configAfterUpdate)
+    })
+
+    it('if config is due to change and updateCourtFees is called twice in same term, it should still use the externally specified future config', async () => {
+      const futureTermId = 100
+      const newConfig = await buildNewConfig(initialConfig)
+      await courtHelper.setConfig(futureTermId, newConfig)
+
+      await feesUpdater.updateCourtFees();
+      await feesUpdater.updateCourtFees();
+
+      const configAfterUpdate = { ...newConfig,
+        jurorFee: feeTokenJurorFee,
+        draftFee: feeTokenDraftFee,
+        settleFee: feeTokenSettleFee
+      }
+      await checkConfig(1, configAfterUpdate)
+    })
+  })
+})

--- a/test/feesUpdater/feesUpdater.js
+++ b/test/feesUpdater/feesUpdater.js
@@ -73,14 +73,13 @@ contract("FeesUpdater", ([_]) => {
     courtHelper = buildHelper()
     controller = await courtHelper.deploy({ ...initialConfig })
 
-    feesUpdater = await FeesUpdater.new(priceOracle.address, controller.address, feeToken.address, stableToken.address, stableFees)
+    feesUpdater = await FeesUpdater.new(priceOracle.address, controller.address, stableToken.address, stableFees)
     await controller.changeFeesUpdater(feesUpdater.address)
   })
 
   it('stores constructor params', async () => {
     assert.equal(await feesUpdater.priceOracle(), priceOracle.address, 'Incorrect price oracle')
     assert.equal(await feesUpdater.court(), controller.address, 'Incorrect court address')
-    assert.equal(await feesUpdater.courtFeeToken(), feeToken.address, 'Incorrect fee token')
     assert.equal(await feesUpdater.courtStableToken(), stableToken.address, 'Incorrect stable token')
     assertBnDeepEqual(await feesUpdater.getStableFees(), stableFees, 'Incorrect stable fees')
   })

--- a/test/feesUpdater/feesUpdater.js
+++ b/test/feesUpdater/feesUpdater.js
@@ -129,5 +129,21 @@ contract("FeesUpdater", ([_]) => {
       }
       await checkConfig(1, configAfterUpdate)
     })
+
+    it('if config is due to change at multiple terms in the future, it uses the latest config', async () => {
+      const configTerm50 = await buildNewConfig(initialConfig)
+      const configTerm100 = await buildNewConfig(configTerm50)
+      await courtHelper.setConfig(50, configTerm50)
+      await courtHelper.setConfig(100, configTerm100)
+
+      await feesUpdater.updateCourtFees();
+
+      const configAfterUpdate = { ...configTerm100,
+        jurorFee: feeTokenJurorFee,
+        draftFee: feeTokenDraftFee,
+        settleFee: feeTokenSettleFee
+      }
+      await checkConfig(1, configAfterUpdate)
+    })
   })
 })

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -381,13 +381,14 @@ module.exports = (web3, artifacts) => {
 
       if (!this.fundsGovernor) this.fundsGovernor = await this._getAccount(0)
       if (!this.configGovernor) this.configGovernor = await this._getAccount(0)
+      if (!this.feesUpdater) this.feesUpdater = await this._getAccount(0)
       if (!this.modulesGovernor) this.modulesGovernor = await this._getAccount(0)
       if (!this.feeToken) this.feeToken = await this.artifacts.require('ERC20Mock').new('Court Fee Token', 'CFT', 18)
       if (!this.jurorToken) this.jurorToken = await this.artifacts.require('ERC20Mock').new('Aragon Network Juror Token', 'ANJ', 18)
 
       this.court = await this.artifacts.require('AragonCourtMock').new(
         [this.termDuration, this.firstTermStartTime],
-        [this.fundsGovernor, this.configGovernor, this.modulesGovernor],
+        [this.fundsGovernor, this.configGovernor, this.feesUpdater, this.modulesGovernor],
         this.feeToken.address,
         [this.jurorFee, this.draftFee, this.settleFee],
         [this.evidenceTerms, this.commitTerms, this.revealTerms, this.appealTerms, this.appealConfirmTerms],


### PR DESCRIPTION
Added FeesUpdater contract for converting fees represented in a stable value to the fee token value.
Added extra config governor which can only update the config.
Added tests.

Needs integration testing on Rinkeby with a real Uniswap exchange and Oracle. Too much hassle importing all the testing setup so just used a mock. If it works on Rinkeby though then it's fine.