### PR TITLE
Term predictable max stake

### DIFF
--- a/contracts/court/AragonCourt.sol
+++ b/contracts/court/AragonCourt.sol
@@ -29,20 +29,20 @@ contract AragonCourt is Controller, IArbitrator {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked to each drafted jurors (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Permyriad multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Permyriad multiple of dispute fees required to confirm appeal
@@ -56,9 +56,9 @@ contract AragonCourt is Controller, IArbitrator {
         address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
@@ -68,9 +68,9 @@ contract AragonCourt is Controller, IArbitrator {
             _governors,
             _feeToken,
             _fees,
-            _roundStateDurations,
-            _pcts,
+            _maxRulingOptions,
             _roundParams,
+            _pcts,
             _appealCollateralParams,
             _jurorsParams
         )

--- a/contracts/court/clock/CourtClock.sol
+++ b/contracts/court/clock/CourtClock.sol
@@ -63,7 +63,7 @@ contract CourtClock is IClock, TimeHelpers {
     *        0. _termDuration Duration in seconds per term
     *        1. _firstTermStartTime Timestamp in seconds when the court will open (to give time for juror on-boarding)
     */
-    constructor(uint64[2] memory _termParams) public {
+    constructor(uint64[2] memory _termParams, ERC20 _celesteToken) public {
         uint64 _termDuration = _termParams[0];
         uint64 _firstTermStartTime = _termParams[1];
 
@@ -75,6 +75,7 @@ contract CourtClock is IClock, TimeHelpers {
 
         // No need for SafeMath: we already checked values above
         terms[0].startTime = _firstTermStartTime - _termDuration;
+        terms[0].celesteTokenTotalSupply = _celesteToken.totalSupply();
     }
 
     /**

--- a/contracts/court/clock/CourtClock.sol
+++ b/contracts/court/clock/CourtClock.sol
@@ -157,6 +157,7 @@ contract CourtClock is IClock, TimeHelpers {
     * @return startTime Term start time
     * @return randomnessBN Block number used for randomness in the requested term
     * @return randomness Randomness computed for the requested term
+    * @return celesteTokenTotalSupply Total supply of the Celeste token
     */
     function getTerm(uint64 _termId) external view returns (uint64 startTime, uint64 randomnessBN, bytes32 randomness, uint256 celesteTokenTotalSupply) {
         Term storage term = terms[_termId];
@@ -170,6 +171,15 @@ contract CourtClock is IClock, TimeHelpers {
     */
     function getTermRandomness(uint64 _termId) external view termExists(_termId) returns (bytes32) {
         return _computeTermRandomness(_termId);
+    }
+
+    /**
+    * @dev Tell the total supply of the celeste token at a specific term
+    * @param _termId Identification number of the term being queried
+    * @return Total supply of celeste token
+    */
+    function getTermTokenTotalSupply(uint64 _termId) external view termExists(_termId) returns (uint256) {
+        return terms[_termId].celesteTokenTotalSupply;
     }
 
     /**
@@ -298,6 +308,36 @@ contract CourtClock is IClock, TimeHelpers {
         return blockhash(term.randomnessBN);
     }
 
+    /**
+    * @dev Tell the full Court configuration parameters at a certain term
+    * @param _termId Identification number of the term querying the Court config of
+    * @return token Address of the token used to pay for fees
+    * @return fees Array containing:
+    *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
+    *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
+    *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
+    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    *         0. evidenceTerms Max submitting evidence period duration in terms
+    *         1. commitTerms Commit period duration in terms
+    *         2. revealTerms Reveal period duration in terms
+    *         3. appealTerms Appeal period duration in terms
+    *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    * @return pcts Array containing:
+    *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
+    *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
+    * @return roundParams Array containing params for rounds:
+    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
+    * @return appealCollateralParams Array containing params for appeal collateral:
+    *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
+    *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
+    * @return jurorsParams Array containing params for juror registry:
+    *         0. minActiveBalance Minimum amount of juror tokens that can be activated
+    *         1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
+    *         2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    */
     function _getConfig(uint64 _termId) internal view returns (
         ERC20 feeToken,
         uint256[3] memory fees,

--- a/contracts/court/clock/CourtClock.sol
+++ b/contracts/court/clock/CourtClock.sol
@@ -316,20 +316,20 @@ contract CourtClock is IClock, TimeHelpers {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *         3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -341,9 +341,9 @@ contract CourtClock is IClock, TimeHelpers {
     function _getConfig(uint64 _termId) internal view returns (
         ERC20 feeToken,
         uint256[3] memory fees,
-        uint64[5] memory roundStateDurations,
+        uint8 maxRulingOptions,
+        uint64[9] memory roundParams,
         uint16[2] memory pcts,
-        uint64[4] memory roundParams,
         uint256[2] memory appealCollateralParams,
         uint256[3] memory jurorsParams
     );

--- a/contracts/court/clock/IClock.sol
+++ b/contracts/court/clock/IClock.sol
@@ -45,6 +45,7 @@ interface IClock {
     * @return startTime Term start time
     * @return randomnessBN Block number used for randomness in the requested term
     * @return randomness Randomness computed for the requested term
+    * @return celesteTokenTotalSupply Total supply of the Celeste token
     */
     function getTerm(uint64 _termId) external view returns (uint64 startTime, uint64 randomnessBN, bytes32 randomness, uint256 celesteTokenTotalSupply);
 
@@ -54,4 +55,11 @@ interface IClock {
     * @return Randomness of the requested term
     */
     function getTermRandomness(uint64 _termId) external view returns (bytes32);
+
+    /**
+    * @dev Tell the total supply of the celeste token at a specific term
+    * @param _termId Identification number of the term being queried
+    * @return Total supply of celeste token
+    */
+    function getTermTokenTotalSupply(uint64 _termId) external view returns (uint256);
 }

--- a/contracts/court/clock/IClock.sol
+++ b/contracts/court/clock/IClock.sol
@@ -46,7 +46,7 @@ interface IClock {
     * @return randomnessBN Block number used for randomness in the requested term
     * @return randomness Randomness computed for the requested term
     */
-    function getTerm(uint64 _termId) external view returns (uint64 startTime, uint64 randomnessBN, bytes32 randomness);
+    function getTerm(uint64 _termId) external view returns (uint64 startTime, uint64 randomnessBN, bytes32 randomness, uint256 celesteTokenTotalSupply);
 
     /**
     * @dev Tell the randomness of a term even if it wasn't computed yet

--- a/contracts/court/config/ConfigConsumer.sol
+++ b/contracts/court/config/ConfigConsumer.sol
@@ -21,9 +21,9 @@ contract ConfigConsumer is CourtConfigData {
     function _getConfigAt(uint64 _termId) internal view returns (Config memory) {
         (ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams) = _courtConfig().getConfig(_termId);
 
@@ -38,16 +38,17 @@ contract ConfigConsumer is CourtConfigData {
         });
 
         config.disputes = DisputesConfig({
-            evidenceTerms: _roundStateDurations[0],
-            commitTerms: _roundStateDurations[1],
-            revealTerms: _roundStateDurations[2],
-            appealTerms: _roundStateDurations[3],
-            appealConfirmTerms: _roundStateDurations[4],
+            maxRulingOptions: maxRulingOptions,
+            evidenceTerms: _roundParams[0],
+            commitTerms: _roundParams[1],
+            revealTerms: _roundParams[2],
+            appealTerms: _roundParams[3],
+            appealConfirmTerms: _roundParams[4],
             penaltyPct: _pcts[0],
-            firstRoundJurorsNumber: _roundParams[0],
-            appealStepFactor: _roundParams[1],
-            maxRegularAppealRounds: _roundParams[2],
-            finalRoundLockTerms: _roundParams[3],
+            firstRoundJurorsNumber: _roundParams[5],
+            appealStepFactor: _roundParams[6],
+            maxRegularAppealRounds: _roundParams[7],
+            finalRoundLockTerms: _roundParams[8],
             appealCollateralFactor: _appealCollateralParams[0],
             appealConfirmCollateralFactor: _appealCollateralParams[1]
         });

--- a/contracts/court/config/CourtConfig.sol
+++ b/contracts/court/config/CourtConfig.sol
@@ -14,6 +14,7 @@ contract CourtConfig is IConfig, CourtConfigData {
 
     string private constant ERROR_TOO_OLD_TERM = "CONF_TOO_OLD_TERM";
     string private constant ERROR_RULING_OPTIONS_LESS_THAN_MIN = "CONF_RULING_OPTIONS_LESS_THAN_MIN";
+    string private constant ERROR_RULING_OPTIONS_MORE_THAN_MAX = "CONF_RULING_OPTIONS_MORE_THAN_MAX";
     string private constant ERROR_INVALID_PENALTY_PCT = "CONF_INVALID_PENALTY_PCT";
     string private constant ERROR_INVALID_FINAL_ROUND_REDUCTION_PCT = "CONF_INVALID_FINAL_ROUND_RED_PCT";
     string private constant ERROR_INVALID_MAX_APPEAL_ROUNDS = "CONF_INVALID_MAX_APPEAL_ROUNDS";
@@ -247,6 +248,8 @@ contract CourtConfig is IConfig, CourtConfigData {
         require(_termId == 0 || _fromTermId > _termId, ERROR_TOO_OLD_TERM);
 
         require(_maxRulingOptions >= 2, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
+        // Ruling options 0, 1 and 2 are reserved for special cases.
+        require(_maxRulingOptions <= uint8(-1) - 3, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
 
         // Make sure appeal collateral factors are greater than zero
         require(_appealCollateralParams[0] > 0 && _appealCollateralParams[1] > 0, ERROR_ZERO_COLLATERAL_FACTOR);

--- a/contracts/court/config/CourtConfig.sol
+++ b/contracts/court/config/CourtConfig.sol
@@ -13,6 +13,7 @@ contract CourtConfig is IConfig, CourtConfigData {
     using PctHelpers for uint256;
 
     string private constant ERROR_TOO_OLD_TERM = "CONF_TOO_OLD_TERM";
+    string private constant ERROR_RULING_OPTIONS_LESS_THAN_MIN = "CONF_RULING_OPTIONS_LESS_THAN_MIN";
     string private constant ERROR_INVALID_PENALTY_PCT = "CONF_INVALID_PENALTY_PCT";
     string private constant ERROR_INVALID_FINAL_ROUND_REDUCTION_PCT = "CONF_INVALID_FINAL_ROUND_RED_PCT";
     string private constant ERROR_INVALID_MAX_APPEAL_ROUNDS = "CONF_INVALID_MAX_APPEAL_ROUNDS";
@@ -53,20 +54,20 @@ contract CourtConfig is IConfig, CourtConfigData {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -78,9 +79,9 @@ contract CourtConfig is IConfig, CourtConfigData {
     constructor(
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
@@ -93,9 +94,9 @@ contract CourtConfig is IConfig, CourtConfigData {
             0,
             _feeToken,
             _fees,
-            _roundStateDurations,
-            _pcts,
+            _maxRulingOptions,
             _roundParams,
+            _pcts,
             _appealCollateralParams,
             _jurorsParams
         );
@@ -118,19 +119,20 @@ contract CourtConfig is IConfig, CourtConfigData {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -143,9 +145,9 @@ contract CourtConfig is IConfig, CourtConfigData {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         );
@@ -205,20 +207,20 @@ contract CourtConfig is IConfig, CourtConfigData {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -232,9 +234,9 @@ contract CourtConfig is IConfig, CourtConfigData {
         uint64 _fromTermId,
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
@@ -244,6 +246,8 @@ contract CourtConfig is IConfig, CourtConfigData {
         // No need to ensure delays for on-going disputes since these already use their creation term for that.
         require(_termId == 0 || _fromTermId > _termId, ERROR_TOO_OLD_TERM);
 
+        require(_maxRulingOptions >= 2, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
+
         // Make sure appeal collateral factors are greater than zero
         require(_appealCollateralParams[0] > 0 && _appealCollateralParams[1] > 0, ERROR_ZERO_COLLATERAL_FACTOR);
 
@@ -252,19 +256,19 @@ contract CourtConfig is IConfig, CourtConfigData {
         require(PctHelpers.isValid(_pcts[1]), ERROR_INVALID_FINAL_ROUND_REDUCTION_PCT);
 
         // Disputes must request at least one juror to be drafted initially
-        require(_roundParams[0] > 0, ERROR_BAD_INITIAL_JURORS_NUMBER);
+        require(_roundParams[5] > 0, ERROR_BAD_INITIAL_JURORS_NUMBER);
 
         // Prevent that further rounds have zero jurors
-        require(_roundParams[1] > 0, ERROR_BAD_APPEAL_STEP_FACTOR);
+        require(_roundParams[6] > 0, ERROR_BAD_APPEAL_STEP_FACTOR);
 
         // Make sure the max number of appeals allowed does not reach the limit
-        uint256 _maxRegularAppealRounds = _roundParams[2];
+        uint256 _maxRegularAppealRounds = _roundParams[7];
         bool isMaxAppealRoundsValid = _maxRegularAppealRounds > 0 && _maxRegularAppealRounds <= MAX_REGULAR_APPEAL_ROUNDS_LIMIT;
         require(isMaxAppealRoundsValid, ERROR_INVALID_MAX_APPEAL_ROUNDS);
 
         // Make sure each adjudication round phase duration is valid
-        for (uint i = 0; i < _roundStateDurations.length; i++) {
-            require(_roundStateDurations[i] > 0 && _roundStateDurations[i] < MAX_ADJ_STATE_DURATION, ERROR_LARGE_ROUND_PHASE_DURATION);
+        for (uint i = 0; i < 5; i++) {
+            require(_roundParams[i] > 0 && _roundParams[i] < MAX_ADJ_STATE_DURATION, ERROR_LARGE_ROUND_PHASE_DURATION);
         }
 
         // Make sure min active balance is not zero
@@ -296,16 +300,17 @@ contract CourtConfig is IConfig, CourtConfigData {
         });
 
         config.disputes = DisputesConfig({
-            evidenceTerms: _roundStateDurations[0],
-            commitTerms: _roundStateDurations[1],
-            revealTerms: _roundStateDurations[2],
-            appealTerms: _roundStateDurations[3],
-            appealConfirmTerms: _roundStateDurations[4],
+            maxRulingOptions: _maxRulingOptions,
+            evidenceTerms: _roundParams[0],
+            commitTerms: _roundParams[1],
+            revealTerms: _roundParams[2],
+            appealTerms: _roundParams[3],
+            appealConfirmTerms: _roundParams[4],
             penaltyPct: _pcts[0],
-            firstRoundJurorsNumber: _roundParams[0],
-            appealStepFactor: _roundParams[1],
+            firstRoundJurorsNumber: _roundParams[5],
+            appealStepFactor: _roundParams[6],
             maxRegularAppealRounds: _maxRegularAppealRounds,
-            finalRoundLockTerms: _roundParams[3],
+            finalRoundLockTerms: _roundParams[8],
             appealCollateralFactor: _appealCollateralParams[0],
             appealConfirmCollateralFactor: _appealCollateralParams[1]
         });
@@ -331,20 +336,20 @@ contract CourtConfig is IConfig, CourtConfigData {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *         3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -357,9 +362,9 @@ contract CourtConfig is IConfig, CourtConfigData {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         )
@@ -371,20 +376,19 @@ contract CourtConfig is IConfig, CourtConfigData {
         fees = [feesConfig.jurorFee, feesConfig.draftFee, feesConfig.settleFee];
 
         DisputesConfig storage disputesConfig = config.disputes;
-        roundStateDurations = [
+        maxRulingOptions = disputesConfig.maxRulingOptions;
+        roundParams = [
             disputesConfig.evidenceTerms,
             disputesConfig.commitTerms,
             disputesConfig.revealTerms,
             disputesConfig.appealTerms,
-            disputesConfig.appealConfirmTerms
-        ];
-        pcts = [disputesConfig.penaltyPct, feesConfig.finalRoundReduction];
-        roundParams = [
+            disputesConfig.appealConfirmTerms,
             disputesConfig.firstRoundJurorsNumber,
             disputesConfig.appealStepFactor,
             uint64(disputesConfig.maxRegularAppealRounds),
             disputesConfig.finalRoundLockTerms
         ];
+        pcts = [disputesConfig.penaltyPct, feesConfig.finalRoundReduction];
         appealCollateralParams = [disputesConfig.appealCollateralFactor, disputesConfig.appealConfirmCollateralFactor];
 
         JurorsConfig storage jurorsConfig = config.jurors;

--- a/contracts/court/config/CourtConfig.sol
+++ b/contracts/court/config/CourtConfig.sol
@@ -249,7 +249,7 @@ contract CourtConfig is IConfig, CourtConfigData {
 
         require(_maxRulingOptions >= 2, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
         // Ruling options 0, 1 and 2 are reserved for special cases.
-        require(_maxRulingOptions <= uint8(-1) - 3, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
+        require(_maxRulingOptions <= uint8(-1) - 3, ERROR_RULING_OPTIONS_MORE_THAN_MAX);
 
         // Make sure appeal collateral factors are greater than zero
         require(_appealCollateralParams[0] > 0 && _appealCollateralParams[1] > 0, ERROR_ZERO_COLLATERAL_FACTOR);

--- a/contracts/court/config/CourtConfigData.sol
+++ b/contracts/court/config/CourtConfigData.sol
@@ -20,6 +20,7 @@ contract CourtConfigData {
     }
 
     struct DisputesConfig {
+        uint8 maxRulingOptions;                 // Max number of options selectable by jurors for a dispute
         uint64 evidenceTerms;                   // Max submitting evidence period duration in terms
         uint64 commitTerms;                     // Committing period duration in terms
         uint64 revealTerms;                     // Revealing period duration in terms

--- a/contracts/court/config/CourtConfigData.sol
+++ b/contracts/court/config/CourtConfigData.sol
@@ -20,7 +20,7 @@ contract CourtConfigData {
     }
 
     struct DisputesConfig {
-        uint8 maxRulingOptions;                 // Max number of options selectable by jurors for a dispute
+        uint8 maxRulingOptions;                 // Max number of ruling options selectable by jurors for a dispute
         uint64 evidenceTerms;                   // Max submitting evidence period duration in terms
         uint64 commitTerms;                     // Committing period duration in terms
         uint64 revealTerms;                     // Revealing period duration in terms

--- a/contracts/court/config/IConfig.sol
+++ b/contracts/court/config/IConfig.sol
@@ -13,19 +13,20 @@ interface IConfig {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -38,9 +39,9 @@ interface IConfig {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         );

--- a/contracts/court/controller/Controller.sol
+++ b/contracts/court/controller/Controller.sol
@@ -323,6 +323,23 @@ contract Controller is IsContract, CourtClock, CourtConfig {
             uint256[3] memory jurorsParams
         )
     {
+        return _getConfig(_termId);
+    }
+
+    /**
+    * @dev This function overrides one in the CourtClock, giving the CourtClock access to the config.
+    */
+    function _getConfig(uint64 _termId) internal view
+        returns (
+            ERC20 feeToken,
+            uint256[3] memory fees,
+            uint64[5] memory roundStateDurations,
+            uint16[2] memory pcts,
+            uint64[4] memory roundParams,
+            uint256[2] memory appealCollateralParams,
+            uint256[3] memory jurorsParams
+        )
+    {
         uint64 lastEnsuredTermId = _lastEnsuredTermId();
         return _getConfigAt(_termId, lastEnsuredTermId);
     }

--- a/contracts/court/controller/Controller.sol
+++ b/contracts/court/controller/Controller.sol
@@ -101,20 +101,20 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked to each drafted jurors (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Permyriad multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Permyriad multiple of dispute fees required to confirm appeal
@@ -128,15 +128,15 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
         public
         CourtClock(_termParams, _feeToken)
-        CourtConfig(_feeToken, _fees, _roundStateDurations, _pcts, _roundParams, _appealCollateralParams, _jurorsParams)
+        CourtConfig(_feeToken, _fees, _maxRulingOptions, _roundParams, _pcts, _appealCollateralParams, _jurorsParams)
     {
         _setFundsGovernor(_governors[0]);
         _setConfigGovernor(_governors[1]);
@@ -152,20 +152,20 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked to each drafted jurors (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Permyriad multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Permyriad multiple of dispute fees required to confirm appeal
@@ -178,9 +178,9 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         uint64 _fromTermId,
         ERC20 _feeToken,
         uint256[3] calldata _fees,
-        uint64[5] calldata _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] calldata _roundParams,
         uint16[2] calldata _pcts,
-        uint64[4] calldata _roundParams,
         uint256[2] calldata _appealCollateralParams,
         uint256[3] calldata _jurorsParams
     )
@@ -193,9 +193,9 @@ contract Controller is IsContract, CourtClock, CourtConfig {
             _fromTermId,
             _feeToken,
             _fees,
-            _roundStateDurations,
-            _pcts,
+            _maxRulingOptions,
             _roundParams,
+            _pcts,
             _appealCollateralParams,
             _jurorsParams
         );
@@ -290,20 +290,20 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *         3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -316,9 +316,9 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         )
@@ -333,9 +333,9 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         )

--- a/contracts/court/controller/Controller.sol
+++ b/contracts/court/controller/Controller.sol
@@ -135,7 +135,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         uint256[3] memory _jurorsParams
     )
         public
-        CourtClock(_termParams)
+        CourtClock(_termParams, _feeToken)
         CourtConfig(_feeToken, _fees, _roundStateDurations, _pcts, _roundParams, _appealCollateralParams, _jurorsParams)
     {
         _setFundsGovernor(_governors[0]);

--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -57,9 +57,6 @@ contract DisputeManager is ControlledRecoverable, ICRVotingOwner, IDisputeManage
     // Minimum possible rulings for a dispute
     uint8 internal constant MIN_RULING_OPTIONS = 2;
 
-    // Maximum possible rulings for a dispute, equal to minimum limit
-    uint8 internal constant MAX_RULING_OPTIONS = MIN_RULING_OPTIONS;
-
     // Precision factor used to improve rounding when computing weights for the final round
     uint256 internal constant FINAL_ROUND_WEIGHT_PRECISION = 1000;
 
@@ -191,7 +188,8 @@ contract DisputeManager is ControlledRecoverable, ICRVotingOwner, IDisputeManage
     */
     function createDispute(IArbitrable _subject, uint8 _possibleRulings, bytes calldata _metadata) external onlyController returns (uint256) {
         uint64 termId = _ensureCurrentTerm();
-        require(_possibleRulings >= MIN_RULING_OPTIONS && _possibleRulings <= MAX_RULING_OPTIONS, ERROR_INVALID_RULING_OPTIONS);
+        Config memory config = _getConfigAt(termId);
+        require(_possibleRulings >= MIN_RULING_OPTIONS && _possibleRulings <= config.disputes.maxRulingOptions, ERROR_INVALID_RULING_OPTIONS);
 
         // Create the dispute
         uint256 disputeId = disputes.length++;
@@ -200,7 +198,6 @@ contract DisputeManager is ControlledRecoverable, ICRVotingOwner, IDisputeManage
         dispute.possibleRulings = _possibleRulings;
         dispute.createTermId = termId;
 
-        Config memory config = _getConfigAt(termId);
         uint64 jurorsNumber = config.disputes.firstRoundJurorsNumber;
         uint64 draftTermId = termId.add(config.disputes.evidenceTerms);
         emit NewDispute(disputeId, _subject, draftTermId, jurorsNumber, _metadata);

--- a/contracts/feesUpdater/FeesUpdater.sol
+++ b/contracts/feesUpdater/FeesUpdater.sol
@@ -9,7 +9,7 @@ contract FeesUpdater {
     IPriceOracle public priceOracle;
     AragonCourt public court;
     address public courtStableToken;
-    uint256[3] public courtStableValueFees;
+    uint256[3] public courtStableValueFees; // [jurorFee, draftFee, settleFee]
 
     constructor(
         IPriceOracle _priceOracle,
@@ -51,7 +51,6 @@ contract FeesUpdater {
         convertedFees[0] = priceOracle.consult(courtStableToken, courtStableValueFees[0], address(feeToken));
         convertedFees[1] = priceOracle.consult(courtStableToken, courtStableValueFees[1], address(feeToken));
         convertedFees[2] = priceOracle.consult(courtStableToken, courtStableValueFees[2], address(feeToken));
-
 
         court.setConfig(currentTerm + 1, feeToken, convertedFees, maxRulingOptions, roundParams, pcts, appealCollateralParams,
             jurorsParams);

--- a/contracts/feesUpdater/FeesUpdater.sol
+++ b/contracts/feesUpdater/FeesUpdater.sol
@@ -40,9 +40,9 @@ contract FeesUpdater {
         // that is scheduled for a future term will be scheduled for the next term instead.
         uint64 latestPossibleTerm = uint64(-1);
         (ERC20 feeToken,,
-        uint64[5] memory roundStateDurations,
+        uint8 maxRulingOptions,
+        uint64[9] memory roundParams,
         uint16[2] memory pcts,
-        uint64[4] memory roundParams,
         uint256[2] memory appealCollateralParams,
         uint256[3] memory jurorsParams
         ) = court.getConfig(latestPossibleTerm);
@@ -52,7 +52,8 @@ contract FeesUpdater {
         convertedFees[1] = priceOracle.consult(courtStableToken, courtStableValueFees[1], address(feeToken));
         convertedFees[2] = priceOracle.consult(courtStableToken, courtStableValueFees[2], address(feeToken));
 
-        court.setConfig(currentTerm + 1, feeToken, convertedFees, roundStateDurations, pcts, roundParams,
-            appealCollateralParams, jurorsParams);
+
+        court.setConfig(currentTerm + 1, feeToken, convertedFees, maxRulingOptions, roundParams, pcts, appealCollateralParams,
+            jurorsParams);
     }
 }

--- a/contracts/registry/JurorsRegistry.sol
+++ b/contracts/registry/JurorsRegistry.sol
@@ -635,9 +635,9 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
         Juror storage juror = jurorsByAddress[_juror];
         uint256 minActiveBalance = _getMinActiveBalance(nextTermId);
         uint256 maxActiveBalance = maxActiveBalance(termId);
-        // Due to fluctuations in issuance we can't ensure min active balance is less than the max active balance
-        // because max active balance is determined using the juror token total supply. Therefore set max active
-        // balance to min active balance if it less then min active balance.
+        // Due to fluctuations in the celeste token's total supply we can't ensure min active balance is less than
+        // the max active balance because max active balance is determined using the celeste token's total supply.
+        // Therefore set max active balance to min active balance if it less then min active balance.
         if (maxActiveBalance < minActiveBalance) {
             maxActiveBalance = minActiveBalance;
         }

--- a/contracts/registry/JurorsRegistry.sol
+++ b/contracts/registry/JurorsRegistry.sol
@@ -552,11 +552,9 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
     * @return Max amount of tokens a juror can activate at this time
     */
     function maxActiveBalance(uint64 _termId) public view returns (uint256) {
-
-        // Check totalSupply isn't 0
-
-        uint256 jurorsTokenTotalSupply = jurorsToken.totalSupply();
-        if (jurorsTokenTotalSupply == 0) {
+        IClock clock = _clock();
+        uint256 celesteTokenTotalSupply = clock.getTermTokenTotalSupply(_termId);
+        if (celesteTokenTotalSupply == 0) {
             return 0;
         }
 
@@ -565,8 +563,8 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
         uint256 diffOfPct = maxMaxPctTotalSupply - minMaxPctTotalSupply; // No need for safemath, we ensure min is less than max in config setting
         uint256 totalActiveBalanceAtTerm = _totalActiveBalanceAt(_termId);
 
-        uint256 currentPctOfTotalSupply = maxMaxPctTotalSupply.sub(totalActiveBalanceAtTerm.mul(diffOfPct) / jurorsTokenTotalSupply);
-        return jurorsTokenTotalSupply.pctHighPrecision(currentPctOfTotalSupply);
+        uint256 currentPctOfTotalSupply = maxMaxPctTotalSupply.sub(totalActiveBalanceAtTerm.mul(diffOfPct) / celesteTokenTotalSupply);
+        return celesteTokenTotalSupply.pctHighPrecision(currentPctOfTotalSupply);
     }
 
     /**

--- a/contracts/registry/JurorsRegistry.sol
+++ b/contracts/registry/JurorsRegistry.sol
@@ -38,7 +38,6 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
     string private constant ERROR_BAD_TOTAL_ACTIVE_BALANCE_LIMIT = "JR_BAD_TOTAL_ACTIVE_BAL_LIMIT";
     string private constant ERROR_TOTAL_ACTIVE_BALANCE_TOO_LOW = "JR_TOTAL_ACTIVE_BALANCE_TOO_LOW";
     string private constant ERROR_TOTAL_ACTIVE_BALANCE_EXCEEDED = "JR_TOTAL_ACTIVE_BALANCE_EXCEEDED";
-    string private constant ERROR_ACTIVE_BALANCE_LIMITS_INCONSISTENT = "JR_ACTIVE_BALANCE_LIMITS_INCONSISTENT";
     string private constant ERROR_WITHDRAWALS_LOCK = "JR_WITHDRAWALS_LOCK";
     string private constant ERROR_SENDER_NOT_BRIGHTID_REGISTER = "JR_SENDER_NOT_BRIGHTID_REGISTER";
     string private constant ERROR_NO_FUNCTION_MATCH = "JR_NO_FUNCTION_MATCH";
@@ -130,17 +129,14 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
     /**
     * @dev Constructor function
     * @param _controller Address of the controller
-    * @param _jurorToken Address of the ERC20 token to be used as juror token for the registry
     * @param _totalActiveBalanceLimit Maximum amount of total active balance that can be held in the registry
     */
-    constructor(Controller _controller, ERC20 _jurorToken, uint256 _totalActiveBalanceLimit)
+    constructor(Controller _controller, uint256 _totalActiveBalanceLimit)
         ControlledRecoverable(_controller)
         public
     {
         // No need to explicitly call `Controlled` constructor since `ControlledRecoverable` is already doing it
-        require(isContract(address(_jurorToken)), ERROR_NOT_CONTRACT);
-
-        jurorsToken = _jurorToken;
+        jurorsToken = _getConfigAt(0).fees.token;
         _setTotalActiveBalanceLimit(_totalActiveBalanceLimit);
 
         tree.init();
@@ -556,6 +552,9 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
     * @return Max amount of tokens a juror can activate at this time
     */
     function maxActiveBalance(uint64 _termId) public view returns (uint256) {
+
+        // Check totalSupply isn't 0
+
         uint256 jurorsTokenTotalSupply = jurorsToken.totalSupply();
         if (jurorsTokenTotalSupply == 0) {
             return 0;
@@ -638,10 +637,12 @@ contract JurorsRegistry is ControlledRecoverable, IJurorsRegistry, ERC900, Appro
         Juror storage juror = jurorsByAddress[_juror];
         uint256 minActiveBalance = _getMinActiveBalance(nextTermId);
         uint256 maxActiveBalance = maxActiveBalance(termId);
-        // Due to min active balance living at the global config level, we can't ensure it is less than the max
-        // active balance when set, because max active balance is determined using the juror token, specific to this
-        // contract. Therefore we revert if the min active balance is more than the max active balance.
-        require(minActiveBalance < maxActiveBalance, ERROR_ACTIVE_BALANCE_LIMITS_INCONSISTENT);
+        // Due to fluctuations in issuance we can't ensure min active balance is less than the max active balance
+        // because max active balance is determined using the juror token total supply. Therefore set max active
+        // balance to min active balance if it less then min active balance.
+        if (maxActiveBalance < minActiveBalance) {
+            maxActiveBalance = minActiveBalance;
+        }
 
         if (_existsJuror(juror)) {
             // Even though we are adding amounts, let's check the new active balance is greater than or equal to the

--- a/contracts/test/court/AragonCourtMock.sol
+++ b/contracts/test/court/AragonCourtMock.sol
@@ -13,9 +13,9 @@ contract AragonCourtMock is AragonCourt, TimeHelpersMock {
         address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
@@ -24,9 +24,9 @@ contract AragonCourtMock is AragonCourt, TimeHelpersMock {
             _governors,
             _feeToken,
             _fees,
-            _roundStateDurations,
-            _pcts,
+            _maxRulingOptions,
             _roundParams,
+            _pcts,
             _appealCollateralParams,
             _jurorsParams
         )

--- a/contracts/test/court/AragonCourtMock.sol
+++ b/contracts/test/court/AragonCourtMock.sol
@@ -101,6 +101,11 @@ contract AragonCourtMock is AragonCourt, TimeHelpersMock {
         return super._computeTermRandomness(_termId);
     }
 
+    function getTermTokenTotalSupply(uint64 _termId) external view returns (uint256) {
+        (ERC20 feeToken,,,,,,) = _getConfig(_termId);
+        return feeToken.totalSupply();
+    }
+
     function _computeTermRandomness(uint64 _termId) internal view returns (bytes32) {
         if (mockedTermRandomness != bytes32(0)) return mockedTermRandomness;
         return super._computeTermRandomness(_termId);

--- a/contracts/test/registry/JurorsRegistryMock.sol
+++ b/contracts/test/registry/JurorsRegistryMock.sol
@@ -9,9 +9,9 @@ contract JurorsRegistryMock is JurorsRegistry {
     bool internal nextDraftMocked;
     address[] internal mockedSelectedJurors;
 
-    constructor (Controller _controller, ERC20 _jurorToken, uint256 _totalActiveBalanceLimit)
+    constructor (Controller _controller, uint256 _totalActiveBalanceLimit)
         public
-        JurorsRegistry(_controller, _jurorToken, _totalActiveBalanceLimit)
+        JurorsRegistry(_controller, _totalActiveBalanceLimit)
     {}
 
     function mockLock(address _juror, uint256 _leftUnlockedAmount) external {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@1hive/celeste",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Celeste Oracle",
   "author": "Aragon Association",
   "license": "GPL-3.0",
   "files": [
     "/abi",
     "/artifacts",
-    "/contracts"
+    "/contracts",
+    "/test"
   ],
   "scripts": {
     "compile": "buidler compile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1hive/celeste",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Celeste Oracle",
   "author": "Aragon Association",
   "license": "GPL-3.0",

--- a/test/court/controller/controller-clock.js
+++ b/test/court/controller/controller-clock.js
@@ -131,6 +131,21 @@ contract('Controller', ([_, someone, configGovernor]) => {
 
         assertBn((await controller.getNeededTermTransitions()), remainingTransitions, 'needed term transitions does not match')
       })
+
+      it(`updates celesteTokenTotalSupply correctly ${expectedTransitions} times`, async () => {
+        const lastEnsuredTermId = await controller.getLastEnsuredTermId()
+
+        for (let transition = 1; transition <= expectedTransitions; transition++) {
+          await controller.heartbeat(bn(1))
+          await ANJ.generateTokens(someone, anjNewSupply)
+          const termId = lastEnsuredTermId.add(bn(transition))
+
+          const { celesteTokenTotalSupply } = await controller.getTerm(termId)
+
+          const expectedTotalSupply = ANJ_INITIAL_TOTAL_SUPPLY.add(anjNewSupply.mul(bn(transition)))
+          assertBn(celesteTokenTotalSupply, expectedTotalSupply, `total supply for term ${termId} incorrect`)
+        }
+      })
     }
 
     context('when current timestamp is before zero term start time', () => {

--- a/test/court/controller/controller-config.js
+++ b/test/court/controller/controller-config.js
@@ -118,6 +118,14 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
         await assertRevert(courtHelper.deploy({ maxRegularAppealRounds: bn(11) }), CONFIG_ERRORS.INVALID_MAX_APPEAL_ROUNDS)
       })
 
+      it('cannot use max ruling options less than 2', async () => {
+        await assertRevert(courtHelper.deploy({ maxRulingOptions: bn(1) }), "CONF_RULING_OPTIONS_LESS_THAN_MIN")
+      })
+
+      it('cannot use max ruling options more than 252', async () => {
+        await assertRevert(courtHelper.deploy({ maxRulingOptions: bn(253) }), "CONF_RULING_OPTIONS_LESS_THAN_MIN")
+      })
+
       it('cannot use a adjudication round durations zero', async () => {
         await assertRevert(courtHelper.deploy({ evidenceTerms: bn(0) }), CONFIG_ERRORS.LARGE_ROUND_PHASE_DURATION)
         await assertRevert(courtHelper.deploy({ commitTerms: bn(0) }), CONFIG_ERRORS.LARGE_ROUND_PHASE_DURATION)

--- a/test/court/controller/controller-config.js
+++ b/test/court/controller/controller-config.js
@@ -123,7 +123,7 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
       })
 
       it('cannot use max ruling options more than 252', async () => {
-        await assertRevert(courtHelper.deploy({ maxRulingOptions: bn(253) }), "CONF_RULING_OPTIONS_LESS_THAN_MIN")
+        await assertRevert(courtHelper.deploy({ maxRulingOptions: bn(253) }), "CONF_RULING_OPTIONS_MORE_THAN_MAX")
       })
 
       it('cannot use a adjudication round durations zero', async () => {

--- a/test/court/controller/controller-config.js
+++ b/test/court/controller/controller-config.js
@@ -15,6 +15,7 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
   const jurorFee = bigExp(10, 18)
   const draftFee = bigExp(30, 18)
   const settleFee = bigExp(40, 18)
+  const maxRulingOptions = bn(2)
   const evidenceTerms = bn(1)
   const commitTerms = bn(1)
   const revealTerms = bn(2)
@@ -41,6 +42,7 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
       jurorFee,
       draftFee,
       settleFee,
+      maxRulingOptions,
       evidenceTerms,
       commitTerms,
       revealTerms,

--- a/test/disputes/disputes-settle-round.js
+++ b/test/disputes/disputes-settle-round.js
@@ -726,7 +726,7 @@ contract('DisputeManager', ([_, drafter, appealMaker, appealTaker, juror500, jur
 
                     afterEach('reactivate jurors and pass final round lock terms', async () => {
                       for (const { address, initialActiveBalance } of jurors) {
-                        const { jurorToken, jurorsRegistry } = courtHelper
+                        const { feeToken, jurorsRegistry } = courtHelper
                         const unlockedBalance = await jurorsRegistry.unlockedActiveBalanceOf(address)
 
                         if (unlockedBalance.gt(initialActiveBalance)) {
@@ -736,8 +736,8 @@ contract('DisputeManager', ([_, drafter, appealMaker, appealTaker, juror500, jur
 
                         if (unlockedBalance.lt(initialActiveBalance)) {
                           const amount = initialActiveBalance.sub(unlockedBalance)
-                          await jurorToken.generateTokens(address, amount)
-                          await jurorToken.approveAndCall(jurorsRegistry.address, amount, ACTIVATE_DATA, { from: address })
+                          await feeToken.generateTokens(address, amount)
+                          await feeToken.approveAndCall(jurorsRegistry.address, amount, ACTIVATE_DATA, { from: address })
                         }
                       }
 

--- a/test/feesUpdater/feesUpdater.js
+++ b/test/feesUpdater/feesUpdater.js
@@ -14,6 +14,7 @@ contract("FeesUpdater", ([_]) => {
   const jurorFee = bigExp(10, 18)
   const draftFee = bigExp(30, 18)
   const settleFee = bigExp(40, 18)
+  const maxRulingOptions = bn(2)
   const evidenceTerms = bn(1)
   const commitTerms = bn(1)
   const revealTerms = bn(2)
@@ -53,6 +54,7 @@ contract("FeesUpdater", ([_]) => {
       jurorFee,
       draftFee,
       settleFee,
+      maxRulingOptions,
       evidenceTerms,
       commitTerms,
       revealTerms,

--- a/test/helpers/utils/config.js
+++ b/test/helpers/utils/config.js
@@ -10,7 +10,7 @@ module.exports = artifacts => {
       jurorFee: config.jurorFee.add(bigExp(iteration * 10, 18)),
       draftFee: config.draftFee.add(bigExp(iteration * 10, 18)),
       settleFee: config.settleFee.add(bigExp(iteration * 10, 18)),
-      maxRulingOptions: config.maxRulingOptions,
+      maxRulingOptions: config.maxRulingOptions.add(bn(iteration)),
       evidenceTerms: config.evidenceTerms.add(bn(iteration)),
       commitTerms: config.commitTerms.add(bn(iteration)),
       revealTerms: config.revealTerms.add(bn(iteration)),

--- a/test/helpers/utils/config.js
+++ b/test/helpers/utils/config.js
@@ -10,6 +10,7 @@ module.exports = artifacts => {
       jurorFee: config.jurorFee.add(bigExp(iteration * 10, 18)),
       draftFee: config.draftFee.add(bigExp(iteration * 10, 18)),
       settleFee: config.settleFee.add(bigExp(iteration * 10, 18)),
+      maxRulingOptions: config.maxRulingOptions,
       evidenceTerms: config.evidenceTerms.add(bn(iteration)),
       commitTerms: config.commitTerms.add(bn(iteration)),
       revealTerms: config.revealTerms.add(bn(iteration)),
@@ -34,6 +35,7 @@ module.exports = artifacts => {
     assertBn(actualConfig.jurorFee, expectedConfig.jurorFee, 'juror fee does not match')
     assertBn(actualConfig.draftFee, expectedConfig.draftFee, 'draft fee does not match')
     assertBn(actualConfig.settleFee, expectedConfig.settleFee, 'settle fee does not match')
+    assertBn(actualConfig.maxRulingOptions, expectedConfig.maxRulingOptions, 'max ruling options does not match')
     assertBn(actualConfig.commitTerms, expectedConfig.commitTerms, 'commit terms number does not match')
     assertBn(actualConfig.revealTerms, expectedConfig.revealTerms, 'reveal terms number does not match')
     assertBn(actualConfig.appealTerms, expectedConfig.appealTerms, 'appeal terms number does not match')

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -204,12 +204,12 @@ module.exports = (web3, artifacts) => {
       const minTotalSupplyRequired = minActiveBalance.div(minMaxPctTotalSupply)
       const minTotalSupplyWithDecimals = bigExp(minTotalSupplyRequired, 18)
       const minTotalSupplyWithExtra = minTotalSupplyWithDecimals.mul(bn(3))
-      await this.jurorToken.generateTokens(await this._getAccount(0), minTotalSupplyWithExtra)
+      await this.feeToken.generateTokens(await this._getAccount(0), minTotalSupplyWithExtra)
 
       for (const { address, initialActiveBalance } of jurors) {
         await this.brightIdHelper.registerUser(address)
-        await this.jurorToken.generateTokens(address, initialActiveBalance)
-        await this.jurorToken.approveAndCall(this.jurorsRegistry.address, initialActiveBalance, ACTIVATE_DATA, { from: address })
+        await this.feeToken.generateTokens(address, initialActiveBalance)
+        await this.feeToken.approveAndCall(this.jurorsRegistry.address, initialActiveBalance, ACTIVATE_DATA, { from: address })
       }
     }
 
@@ -383,8 +383,7 @@ module.exports = (web3, artifacts) => {
       if (!this.configGovernor) this.configGovernor = await this._getAccount(0)
       if (!this.feesUpdater) this.feesUpdater = await this._getAccount(0)
       if (!this.modulesGovernor) this.modulesGovernor = await this._getAccount(0)
-      if (!this.feeToken) this.feeToken = await this.artifacts.require('ERC20Mock').new('Court Fee Token', 'CFT', 18)
-      if (!this.jurorToken) this.jurorToken = await this.artifacts.require('ERC20Mock').new('Aragon Network Juror Token', 'ANJ', 18)
+      if (!this.feeToken) this.feeToken = await this.artifacts.require('ERC20Mock').new('Court Token', 'CTT', 18)
 
       this.court = await this.artifacts.require('AragonCourtMock').new(
         [this.termDuration, this.firstTermStartTime],
@@ -411,7 +410,6 @@ module.exports = (web3, artifacts) => {
       if (!this.jurorsRegistry) {
         this.jurorsRegistry = await this.artifacts.require('JurorsRegistryMock').new(
           this.court.address,
-          this.jurorToken.address,
           this.minActiveBalance.mul(MAX_UINT64.div(this.finalRoundWeightPrecision))
         )
       }

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -38,6 +38,7 @@ const DEFAULTS = {
   firstTermStartTime:                 bn(NEXT_WEEK),   //  first term starts one week after mocked timestamp
   skippedDisputes:                    bn(0),           //  number of disputes to be skipped
   maxJurorsPerDraftBatch:             bn(10),          //  max number of jurors drafted per batch
+  maxRulingOptions:                   bn(2),           //  max number of selectable outcomes for jurors
   evidenceTerms:                      bn(4),           //  evidence period lasts 4 terms maximum
   commitTerms:                        bn(2),           //  vote commits last 2 terms
   revealTerms:                        bn(2),           //  vote reveals last 2 terms
@@ -72,23 +73,24 @@ module.exports = (web3, artifacts) => {
     }
 
     async getConfig(termId) {
-      const { feeToken, fees, roundStateDurations, pcts, roundParams, appealCollateralParams, jurorsParams } = await this.court.getConfig(termId)
+      const { feeToken, fees, maxRulingOptions, roundParams, pcts, appealCollateralParams, jurorsParams } = await this.court.getConfig(termId)
       return {
         feeToken: await this.artifacts.require('ERC20Mock').at(feeToken),
         jurorFee: fees[0],
         draftFee: fees[1],
         settleFee: fees[2],
-        evidenceTerms: roundStateDurations[0],
-        commitTerms: roundStateDurations[1],
-        revealTerms: roundStateDurations[2],
-        appealTerms: roundStateDurations[3],
-        appealConfirmTerms: roundStateDurations[4],
+        maxRulingOptions: maxRulingOptions,
+        evidenceTerms: roundParams[0],
+        commitTerms: roundParams[1],
+        revealTerms: roundParams[2],
+        appealTerms: roundParams[3],
+        appealConfirmTerms: roundParams[4],
         penaltyPct: pcts[0],
         finalRoundReduction: pcts[1],
-        firstRoundJurorsNumber: roundParams[0],
-        appealStepFactor: roundParams[1],
-        maxRegularAppealRounds: roundParams[2],
-        finalRoundLockTerms: roundParams[3],
+        firstRoundJurorsNumber: roundParams[5],
+        appealStepFactor: roundParams[6],
+        maxRegularAppealRounds: roundParams[7],
+        finalRoundLockTerms: roundParams[8],
         appealCollateralFactor: appealCollateralParams[0],
         appealConfirmCollateralFactor: appealCollateralParams[1],
         minActiveBalance: jurorsParams[0],
@@ -356,9 +358,9 @@ module.exports = (web3, artifacts) => {
       const {
         feeToken,
         jurorFee, draftFee, settleFee,
-        evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms,
+        maxRulingOptions,
+        evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms, firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms,
         penaltyPct, finalRoundReduction,
-        firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms,
         appealCollateralFactor, appealConfirmCollateralFactor,
         minActiveBalance, minMaxPctTotalSupply, maxMaxPctTotalSupply
       } = newConfig
@@ -367,9 +369,9 @@ module.exports = (web3, artifacts) => {
         termId,
         feeToken.address,
         [jurorFee, draftFee, settleFee],
-        [evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms],
+        maxRulingOptions,
+        [evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms, firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms],
         [penaltyPct, finalRoundReduction],
-        [firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms],
         [appealCollateralFactor, appealConfirmCollateralFactor],
         [minActiveBalance, minMaxPctTotalSupply, maxMaxPctTotalSupply],
         txParams

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -38,7 +38,7 @@ const DEFAULTS = {
   firstTermStartTime:                 bn(NEXT_WEEK),   //  first term starts one week after mocked timestamp
   skippedDisputes:                    bn(0),           //  number of disputes to be skipped
   maxJurorsPerDraftBatch:             bn(10),          //  max number of jurors drafted per batch
-  maxRulingOptions:                   bn(3),           //  max number of selectable outcomes for jurors
+  maxRulingOptions:                   bn(2),           //  max number of selectable outcomes for jurors
   evidenceTerms:                      bn(4),           //  evidence period lasts 4 terms maximum
   commitTerms:                        bn(2),           //  vote commits last 2 terms
   revealTerms:                        bn(2),           //  vote reveals last 2 terms

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -38,7 +38,7 @@ const DEFAULTS = {
   firstTermStartTime:                 bn(NEXT_WEEK),   //  first term starts one week after mocked timestamp
   skippedDisputes:                    bn(0),           //  number of disputes to be skipped
   maxJurorsPerDraftBatch:             bn(10),          //  max number of jurors drafted per batch
-  maxRulingOptions:                   bn(2),           //  max number of selectable outcomes for jurors
+  maxRulingOptions:                   bn(3),           //  max number of selectable outcomes for jurors
   evidenceTerms:                      bn(4),           //  evidence period lasts 4 terms maximum
   commitTerms:                        bn(2),           //  vote commits last 2 terms
   revealTerms:                        bn(2),           //  vote reveals last 2 terms

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -390,9 +390,9 @@ module.exports = (web3, artifacts) => {
         [this.fundsGovernor, this.configGovernor, this.feesUpdater, this.modulesGovernor],
         this.feeToken.address,
         [this.jurorFee, this.draftFee, this.settleFee],
-        [this.evidenceTerms, this.commitTerms, this.revealTerms, this.appealTerms, this.appealConfirmTerms],
+        this.maxRulingOptions,
+        [this.evidenceTerms, this.commitTerms, this.revealTerms, this.appealTerms, this.appealConfirmTerms, this.firstRoundJurorsNumber, this.appealStepFactor, this.maxRegularAppealRounds, this.finalRoundLockTerms],
         [this.penaltyPct, this.finalRoundReduction],
-        [this.firstRoundJurorsNumber, this.appealStepFactor, this.maxRegularAppealRounds, this.finalRoundLockTerms],
         [this.appealCollateralFactor, this.appealConfirmCollateralFactor],
         [this.minActiveBalance, this.minMaxPctTotalSupply, this.maxMaxPctTotalSupply]
       )

--- a/test/registry/jurors-registry-assign-tokens.js
+++ b/test/registry/jurors-registry-assign-tokens.js
@@ -19,10 +19,10 @@ contract('JurorsRegistry', ([_, juror, someone, jurorUniqueAddress]) => {
   const BURN_ADDRESS = '0x000000000000000000000000000000000000dead'
 
   before('create base contracts', async () => {
-    controller = await buildHelper().deploy({ juror })
+    ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
+    controller = await buildHelper().deploy({ juror, feeToken: ANJ })
     disputeManager = await DisputeManager.new(controller.address)
     await controller.setDisputeManager(disputeManager.address)
-    ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
   })
 
   beforeEach('create jurors registry module', async () => {
@@ -31,7 +31,7 @@ contract('JurorsRegistry', ([_, juror, someone, jurorUniqueAddress]) => {
     await brightIdHelper.registerUserWithMultipleAddresses(jurorUniqueAddress, juror)
     await controller.setBrightIdRegister(brightIdRegister.address)
 
-    registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
+    registry = await JurorsRegistry.new(controller.address, TOTAL_ACTIVE_BALANCE_LIMIT)
     await controller.setJurorsRegistry(registry.address)
   })
 

--- a/test/registry/jurors-registry-drafting.js
+++ b/test/registry/jurors-registry-drafting.js
@@ -62,11 +62,12 @@ contract('JurorsRegistry', ([_, juror500, juror1000, juror1500, juror2000, juror
   })
 
   beforeEach('create base contracts', async () => {
-    controller = await buildHelper().deploy({ minActiveBalance: MIN_ACTIVE_AMOUNT, maxMaxPctTotalSupply: MAX_MAX_PCT_TOTAL_SUPPLY })
+    ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
+    controller = await buildHelper().deploy({ minActiveBalance: MIN_ACTIVE_AMOUNT,
+      maxMaxPctTotalSupply: MAX_MAX_PCT_TOTAL_SUPPLY, feeToken: ANJ })
     await controller.setBrightIdRegister(brightIdRegister.address)
 
-    ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
-    registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
+    registry = await JurorsRegistry.new(controller.address, TOTAL_ACTIVE_BALANCE_LIMIT)
     await controller.setJurorsRegistry(registry.address)
 
     disputeManager = await DisputeManager.new(controller.address)

--- a/test/registry/jurors-registry-initialization.js
+++ b/test/registry/jurors-registry-initialization.js
@@ -16,8 +16,8 @@ contract('JurorsRegistry', ([_, something]) => {
   const TOTAL_ACTIVE_BALANCE_LIMIT = bigExp(100e6, 18)
 
   beforeEach('create base contracts', async () => {
-    controller = await buildHelper().deploy()
     ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
+    controller = await buildHelper().deploy({ feeToken: ANJ })
 
     const brightIdHelper = buildBrightIdHelper()
     brightIdRegister = await brightIdHelper.deploy()
@@ -26,7 +26,7 @@ contract('JurorsRegistry', ([_, something]) => {
   describe('initialize', () => {
     context('when the initialization succeeds', () => {
       it('sets initial config correctly', async () => {
-        const registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
+        const registry = await JurorsRegistry.new(controller.address, TOTAL_ACTIVE_BALANCE_LIMIT)
 
         assert.isFalse(await registry.supportsHistory())
         assert.equal(await registry.getController(), controller.address, 'registry controller does not match')
@@ -36,27 +36,11 @@ contract('JurorsRegistry', ([_, something]) => {
     })
 
     context('initialization fails', () => {
-      context('when the given token address is the zero address', () => {
-        const token = ZERO_ADDRESS
-
-        it('reverts', async () => {
-          await assertRevert(JurorsRegistry.new(controller.address, token, TOTAL_ACTIVE_BALANCE_LIMIT), REGISTRY_ERRORS.NOT_CONTRACT)
-        })
-      })
-
-      context('when the given token address is not a contract address', () => {
-        const token = something
-
-        it('reverts', async () => {
-          await assertRevert(JurorsRegistry.new(controller.address, token, TOTAL_ACTIVE_BALANCE_LIMIT), REGISTRY_ERRORS.NOT_CONTRACT)
-        })
-      })
-
       context('when the given total active balance limit is zero', () => {
         const totalActiveBalanceLimit = 0
 
         it('reverts', async () => {
-          await assertRevert(JurorsRegistry.new(controller.address, ANJ.address, totalActiveBalanceLimit), REGISTRY_ERRORS.BAD_TOTAL_ACTIVE_BAL_LIMIT)
+          await assertRevert(JurorsRegistry.new(controller.address, totalActiveBalanceLimit), REGISTRY_ERRORS.BAD_TOTAL_ACTIVE_BAL_LIMIT)
         })
       })
 
@@ -64,7 +48,7 @@ contract('JurorsRegistry', ([_, something]) => {
         const controllerAddress = ZERO_ADDRESS
 
         it('reverts', async () => {
-          await assertRevert(JurorsRegistry.new(controllerAddress, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT), CONTROLLED_ERRORS.CONTROLLER_NOT_CONTRACT)
+          await assertRevert(JurorsRegistry.new(controllerAddress, TOTAL_ACTIVE_BALANCE_LIMIT), CONTROLLED_ERRORS.CONTROLLER_NOT_CONTRACT)
         })
       })
 
@@ -72,7 +56,7 @@ contract('JurorsRegistry', ([_, something]) => {
         const controllerAddress = something
 
         it('reverts', async () => {
-          await assertRevert(JurorsRegistry.new(controllerAddress, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT), CONTROLLED_ERRORS.CONTROLLER_NOT_CONTRACT)
+          await assertRevert(JurorsRegistry.new(controllerAddress, TOTAL_ACTIVE_BALANCE_LIMIT), CONTROLLED_ERRORS.CONTROLLER_NOT_CONTRACT)
         })
       })
     })

--- a/test/registry/jurors-registry-setters.js
+++ b/test/registry/jurors-registry-setters.js
@@ -18,12 +18,13 @@ contract('JurorsRegistry', ([_, governor, someone]) => {
   const TOTAL_ACTIVE_BALANCE_LIMIT = bigExp(100e6, 18)
 
   before('create base contracts', async () => {
-    controller = await buildHelper().deploy({ configGovernor: governor, minActiveBalance: MIN_ACTIVE_BALANCE })
     ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
+    controller = await buildHelper().deploy({ configGovernor: governor, minActiveBalance: MIN_ACTIVE_BALANCE,
+      feeToken: ANJ })
   })
 
   beforeEach('create jurors registry module', async () => {
-    registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
+    registry = await JurorsRegistry.new(controller.address, TOTAL_ACTIVE_BALANCE_LIMIT)
     await controller.setJurorsRegistry(registry.address)
   })
 

--- a/test/registry/jurors-registry-slashing.js
+++ b/test/registry/jurors-registry-slashing.js
@@ -27,13 +27,14 @@ contract('JurorsRegistry', ([_, juror, secondJuror, thirdJuror, fourthJuror, any
   const EMPTY_RANDOMNESS = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
   before('create base contracts', async () => {
+    ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
     controller = await buildHelper().deploy({
       minActiveBalance: MIN_ACTIVE_AMOUNT,
-      maxMaxPctTotalSupply: MAX_MAX_PCT_TOTAL_SUPPLY
+      maxMaxPctTotalSupply: MAX_MAX_PCT_TOTAL_SUPPLY,
+      feeToken: ANJ
     })
     disputeManager = await DisputeManager.new(controller.address)
     await controller.setDisputeManager(disputeManager.address)
-    ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
   })
 
   beforeEach('create jurors registry module', async () => {
@@ -43,7 +44,7 @@ contract('JurorsRegistry', ([_, juror, secondJuror, thirdJuror, fourthJuror, any
       [secondJurorBrightIdAddress, secondJuror], [thirdJurorBrightIdAddress, thirdJuror], [fourthJurorBrightIdAddress, fourthJuror]])
     await controller.setBrightIdRegister(brightIdRegister.address)
 
-    registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
+    registry = await JurorsRegistry.new(controller.address, TOTAL_ACTIVE_BALANCE_LIMIT)
     await controller.setJurorsRegistry(registry.address)
   })
 

--- a/test/registry/jurors-registry-staking.js
+++ b/test/registry/jurors-registry-staking.js
@@ -21,21 +21,19 @@ contract('JurorsRegistry', ([_, juror, juror2, jurorBrightIdAddress, juror2Brigh
   const MIN_ACTIVE_AMOUNT = bigExp(100, 18)
   const TOTAL_ACTIVE_BALANCE_LIMIT = bigExp(100e6, 18)
 
-  before('create court and custom disputes module', async () => {
-    controller = await buildHelper().deploy({ minActiveBalance: MIN_ACTIVE_AMOUNT })
+  beforeEach('create court and custom disputes module and jurors registry module', async () => {
+    ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
+    controller = await buildHelper().deploy({ minActiveBalance: MIN_ACTIVE_AMOUNT, feeToken: ANJ })
     disputeManager = await DisputeManager.new(controller.address)
     await controller.setDisputeManager(disputeManager.address)
-  })
 
-  beforeEach('create jurors registry module', async () => {
-    ANJ = await ERC20.new('ANJ Token', 'ANJ', 18)
     brightIdHelper = buildBrightIdHelper()
     brightIdRegister = await brightIdHelper.deploy()
     await brightIdHelper.registerUsersWithMultipleAddresses(
       [[jurorBrightIdAddress, juror], [juror2BrightIdAddress, juror2]])
     await controller.setBrightIdRegister(brightIdRegister.address)
 
-    registry = await JurorsRegistry.new(controller.address, ANJ.address, TOTAL_ACTIVE_BALANCE_LIMIT)
+    registry = await JurorsRegistry.new(controller.address, TOTAL_ACTIVE_BALANCE_LIMIT)
     await controller.setJurorsRegistry(registry.address)
 
     // Uncomment the below to test calling stake() and unstake() via the BrightIdRegister. Note some tests are expected to fail


### PR DESCRIPTION
Store the Celeste Token's total supply when calling `heartbeat()`, use this to determine the max stake a juror can activate.

Set max active tokens to min active tokens when min is more than max. This mitigates any issues where the max a keeper can activate gets too small due to issuance decreasing the total supply.