### PR TITLE
Configurable number of ruling options.

### DIFF
--- a/contracts/court/AragonCourt.sol
+++ b/contracts/court/AragonCourt.sol
@@ -29,20 +29,20 @@ contract AragonCourt is Controller, IArbitrator {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked to each drafted jurors (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Permyriad multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Permyriad multiple of dispute fees required to confirm appeal
@@ -56,9 +56,9 @@ contract AragonCourt is Controller, IArbitrator {
         address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
@@ -68,9 +68,9 @@ contract AragonCourt is Controller, IArbitrator {
             _governors,
             _feeToken,
             _fees,
-            _roundStateDurations,
-            _pcts,
+            _maxRulingOptions,
             _roundParams,
+            _pcts,
             _appealCollateralParams,
             _jurorsParams
         )

--- a/contracts/court/clock/CourtClock.sol
+++ b/contracts/court/clock/CourtClock.sol
@@ -316,20 +316,20 @@ contract CourtClock is IClock, TimeHelpers {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *         3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -341,9 +341,9 @@ contract CourtClock is IClock, TimeHelpers {
     function _getConfig(uint64 _termId) internal view returns (
         ERC20 feeToken,
         uint256[3] memory fees,
-        uint64[5] memory roundStateDurations,
+        uint8 maxRulingOptions,
+        uint64[9] memory roundParams,
         uint16[2] memory pcts,
-        uint64[4] memory roundParams,
         uint256[2] memory appealCollateralParams,
         uint256[3] memory jurorsParams
     );

--- a/contracts/court/config/ConfigConsumer.sol
+++ b/contracts/court/config/ConfigConsumer.sol
@@ -21,9 +21,9 @@ contract ConfigConsumer is CourtConfigData {
     function _getConfigAt(uint64 _termId) internal view returns (Config memory) {
         (ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams) = _courtConfig().getConfig(_termId);
 
@@ -38,16 +38,17 @@ contract ConfigConsumer is CourtConfigData {
         });
 
         config.disputes = DisputesConfig({
-            evidenceTerms: _roundStateDurations[0],
-            commitTerms: _roundStateDurations[1],
-            revealTerms: _roundStateDurations[2],
-            appealTerms: _roundStateDurations[3],
-            appealConfirmTerms: _roundStateDurations[4],
+            maxRulingOptions: maxRulingOptions,
+            evidenceTerms: _roundParams[0],
+            commitTerms: _roundParams[1],
+            revealTerms: _roundParams[2],
+            appealTerms: _roundParams[3],
+            appealConfirmTerms: _roundParams[4],
             penaltyPct: _pcts[0],
-            firstRoundJurorsNumber: _roundParams[0],
-            appealStepFactor: _roundParams[1],
-            maxRegularAppealRounds: _roundParams[2],
-            finalRoundLockTerms: _roundParams[3],
+            firstRoundJurorsNumber: _roundParams[5],
+            appealStepFactor: _roundParams[6],
+            maxRegularAppealRounds: _roundParams[7],
+            finalRoundLockTerms: _roundParams[8],
             appealCollateralFactor: _appealCollateralParams[0],
             appealConfirmCollateralFactor: _appealCollateralParams[1]
         });

--- a/contracts/court/config/CourtConfig.sol
+++ b/contracts/court/config/CourtConfig.sol
@@ -14,6 +14,7 @@ contract CourtConfig is IConfig, CourtConfigData {
 
     string private constant ERROR_TOO_OLD_TERM = "CONF_TOO_OLD_TERM";
     string private constant ERROR_RULING_OPTIONS_LESS_THAN_MIN = "CONF_RULING_OPTIONS_LESS_THAN_MIN";
+    string private constant ERROR_RULING_OPTIONS_MORE_THAN_MAX = "CONF_RULING_OPTIONS_MORE_THAN_MAX";
     string private constant ERROR_INVALID_PENALTY_PCT = "CONF_INVALID_PENALTY_PCT";
     string private constant ERROR_INVALID_FINAL_ROUND_REDUCTION_PCT = "CONF_INVALID_FINAL_ROUND_RED_PCT";
     string private constant ERROR_INVALID_MAX_APPEAL_ROUNDS = "CONF_INVALID_MAX_APPEAL_ROUNDS";
@@ -247,6 +248,8 @@ contract CourtConfig is IConfig, CourtConfigData {
         require(_termId == 0 || _fromTermId > _termId, ERROR_TOO_OLD_TERM);
 
         require(_maxRulingOptions >= 2, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
+        // Ruling options 0, 1 and 2 are reserved for special cases.
+        require(_maxRulingOptions <= uint8(-1) - 3, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
 
         // Make sure appeal collateral factors are greater than zero
         require(_appealCollateralParams[0] > 0 && _appealCollateralParams[1] > 0, ERROR_ZERO_COLLATERAL_FACTOR);

--- a/contracts/court/config/CourtConfig.sol
+++ b/contracts/court/config/CourtConfig.sol
@@ -13,6 +13,7 @@ contract CourtConfig is IConfig, CourtConfigData {
     using PctHelpers for uint256;
 
     string private constant ERROR_TOO_OLD_TERM = "CONF_TOO_OLD_TERM";
+    string private constant ERROR_RULING_OPTIONS_LESS_THAN_MIN = "CONF_RULING_OPTIONS_LESS_THAN_MIN";
     string private constant ERROR_INVALID_PENALTY_PCT = "CONF_INVALID_PENALTY_PCT";
     string private constant ERROR_INVALID_FINAL_ROUND_REDUCTION_PCT = "CONF_INVALID_FINAL_ROUND_RED_PCT";
     string private constant ERROR_INVALID_MAX_APPEAL_ROUNDS = "CONF_INVALID_MAX_APPEAL_ROUNDS";
@@ -53,20 +54,20 @@ contract CourtConfig is IConfig, CourtConfigData {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -78,9 +79,9 @@ contract CourtConfig is IConfig, CourtConfigData {
     constructor(
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
@@ -93,9 +94,9 @@ contract CourtConfig is IConfig, CourtConfigData {
             0,
             _feeToken,
             _fees,
-            _roundStateDurations,
-            _pcts,
+            _maxRulingOptions,
             _roundParams,
+            _pcts,
             _appealCollateralParams,
             _jurorsParams
         );
@@ -118,19 +119,20 @@ contract CourtConfig is IConfig, CourtConfigData {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -143,9 +145,9 @@ contract CourtConfig is IConfig, CourtConfigData {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         );
@@ -205,20 +207,20 @@ contract CourtConfig is IConfig, CourtConfigData {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -232,9 +234,9 @@ contract CourtConfig is IConfig, CourtConfigData {
         uint64 _fromTermId,
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
@@ -244,6 +246,8 @@ contract CourtConfig is IConfig, CourtConfigData {
         // No need to ensure delays for on-going disputes since these already use their creation term for that.
         require(_termId == 0 || _fromTermId > _termId, ERROR_TOO_OLD_TERM);
 
+        require(_maxRulingOptions >= 2, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
+
         // Make sure appeal collateral factors are greater than zero
         require(_appealCollateralParams[0] > 0 && _appealCollateralParams[1] > 0, ERROR_ZERO_COLLATERAL_FACTOR);
 
@@ -252,19 +256,19 @@ contract CourtConfig is IConfig, CourtConfigData {
         require(PctHelpers.isValid(_pcts[1]), ERROR_INVALID_FINAL_ROUND_REDUCTION_PCT);
 
         // Disputes must request at least one juror to be drafted initially
-        require(_roundParams[0] > 0, ERROR_BAD_INITIAL_JURORS_NUMBER);
+        require(_roundParams[5] > 0, ERROR_BAD_INITIAL_JURORS_NUMBER);
 
         // Prevent that further rounds have zero jurors
-        require(_roundParams[1] > 0, ERROR_BAD_APPEAL_STEP_FACTOR);
+        require(_roundParams[6] > 0, ERROR_BAD_APPEAL_STEP_FACTOR);
 
         // Make sure the max number of appeals allowed does not reach the limit
-        uint256 _maxRegularAppealRounds = _roundParams[2];
+        uint256 _maxRegularAppealRounds = _roundParams[7];
         bool isMaxAppealRoundsValid = _maxRegularAppealRounds > 0 && _maxRegularAppealRounds <= MAX_REGULAR_APPEAL_ROUNDS_LIMIT;
         require(isMaxAppealRoundsValid, ERROR_INVALID_MAX_APPEAL_ROUNDS);
 
         // Make sure each adjudication round phase duration is valid
-        for (uint i = 0; i < _roundStateDurations.length; i++) {
-            require(_roundStateDurations[i] > 0 && _roundStateDurations[i] < MAX_ADJ_STATE_DURATION, ERROR_LARGE_ROUND_PHASE_DURATION);
+        for (uint i = 0; i < 5; i++) {
+            require(_roundParams[i] > 0 && _roundParams[i] < MAX_ADJ_STATE_DURATION, ERROR_LARGE_ROUND_PHASE_DURATION);
         }
 
         // Make sure min active balance is not zero
@@ -296,16 +300,17 @@ contract CourtConfig is IConfig, CourtConfigData {
         });
 
         config.disputes = DisputesConfig({
-            evidenceTerms: _roundStateDurations[0],
-            commitTerms: _roundStateDurations[1],
-            revealTerms: _roundStateDurations[2],
-            appealTerms: _roundStateDurations[3],
-            appealConfirmTerms: _roundStateDurations[4],
+            maxRulingOptions: _maxRulingOptions,
+            evidenceTerms: _roundParams[0],
+            commitTerms: _roundParams[1],
+            revealTerms: _roundParams[2],
+            appealTerms: _roundParams[3],
+            appealConfirmTerms: _roundParams[4],
             penaltyPct: _pcts[0],
-            firstRoundJurorsNumber: _roundParams[0],
-            appealStepFactor: _roundParams[1],
+            firstRoundJurorsNumber: _roundParams[5],
+            appealStepFactor: _roundParams[6],
             maxRegularAppealRounds: _maxRegularAppealRounds,
-            finalRoundLockTerms: _roundParams[3],
+            finalRoundLockTerms: _roundParams[8],
             appealCollateralFactor: _appealCollateralParams[0],
             appealConfirmCollateralFactor: _appealCollateralParams[1]
         });
@@ -331,20 +336,20 @@ contract CourtConfig is IConfig, CourtConfigData {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *         3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -357,9 +362,9 @@ contract CourtConfig is IConfig, CourtConfigData {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         )
@@ -371,20 +376,19 @@ contract CourtConfig is IConfig, CourtConfigData {
         fees = [feesConfig.jurorFee, feesConfig.draftFee, feesConfig.settleFee];
 
         DisputesConfig storage disputesConfig = config.disputes;
-        roundStateDurations = [
+        maxRulingOptions = disputesConfig.maxRulingOptions;
+        roundParams = [
             disputesConfig.evidenceTerms,
             disputesConfig.commitTerms,
             disputesConfig.revealTerms,
             disputesConfig.appealTerms,
-            disputesConfig.appealConfirmTerms
-        ];
-        pcts = [disputesConfig.penaltyPct, feesConfig.finalRoundReduction];
-        roundParams = [
+            disputesConfig.appealConfirmTerms,
             disputesConfig.firstRoundJurorsNumber,
             disputesConfig.appealStepFactor,
             uint64(disputesConfig.maxRegularAppealRounds),
             disputesConfig.finalRoundLockTerms
         ];
+        pcts = [disputesConfig.penaltyPct, feesConfig.finalRoundReduction];
         appealCollateralParams = [disputesConfig.appealCollateralFactor, disputesConfig.appealConfirmCollateralFactor];
 
         JurorsConfig storage jurorsConfig = config.jurors;

--- a/contracts/court/config/CourtConfig.sol
+++ b/contracts/court/config/CourtConfig.sol
@@ -249,7 +249,7 @@ contract CourtConfig is IConfig, CourtConfigData {
 
         require(_maxRulingOptions >= 2, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
         // Ruling options 0, 1 and 2 are reserved for special cases.
-        require(_maxRulingOptions <= uint8(-1) - 3, ERROR_RULING_OPTIONS_LESS_THAN_MIN);
+        require(_maxRulingOptions <= uint8(-1) - 3, ERROR_RULING_OPTIONS_MORE_THAN_MAX);
 
         // Make sure appeal collateral factors are greater than zero
         require(_appealCollateralParams[0] > 0 && _appealCollateralParams[1] > 0, ERROR_ZERO_COLLATERAL_FACTOR);

--- a/contracts/court/config/CourtConfigData.sol
+++ b/contracts/court/config/CourtConfigData.sol
@@ -20,6 +20,7 @@ contract CourtConfigData {
     }
 
     struct DisputesConfig {
+        uint8 maxRulingOptions;                 // Max number of options selectable by jurors for a dispute
         uint64 evidenceTerms;                   // Max submitting evidence period duration in terms
         uint64 commitTerms;                     // Committing period duration in terms
         uint64 revealTerms;                     // Revealing period duration in terms

--- a/contracts/court/config/CourtConfigData.sol
+++ b/contracts/court/config/CourtConfigData.sol
@@ -20,7 +20,7 @@ contract CourtConfigData {
     }
 
     struct DisputesConfig {
-        uint8 maxRulingOptions;                 // Max number of options selectable by jurors for a dispute
+        uint8 maxRulingOptions;                 // Max number of ruling options selectable by jurors for a dispute
         uint64 evidenceTerms;                   // Max submitting evidence period duration in terms
         uint64 commitTerms;                     // Committing period duration in terms
         uint64 revealTerms;                     // Revealing period duration in terms

--- a/contracts/court/config/IConfig.sol
+++ b/contracts/court/config/IConfig.sol
@@ -13,19 +13,20 @@ interface IConfig {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -38,9 +39,9 @@ interface IConfig {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         );

--- a/contracts/court/controller/Controller.sol
+++ b/contracts/court/controller/Controller.sol
@@ -101,20 +101,20 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked to each drafted jurors (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Permyriad multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Permyriad multiple of dispute fees required to confirm appeal
@@ -128,15 +128,15 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
         public
         CourtClock(_termParams, _feeToken)
-        CourtConfig(_feeToken, _fees, _roundStateDurations, _pcts, _roundParams, _appealCollateralParams, _jurorsParams)
+        CourtConfig(_feeToken, _fees, _maxRulingOptions, _roundParams, _pcts, _appealCollateralParams, _jurorsParams)
     {
         _setFundsGovernor(_governors[0]);
         _setConfigGovernor(_governors[1]);
@@ -152,20 +152,20 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     *        0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *        1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *        2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @param _roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @param _maxRulingOptions Max number of selectable outcomes for each dispute
+    * @param _roundParams Array containing durations of phases of a dispute and other params for rounds:
     *        0. evidenceTerms Max submitting evidence period duration in terms
     *        1. commitTerms Commit period duration in terms
     *        2. revealTerms Reveal period duration in terms
     *        3. appealTerms Appeal period duration in terms
     *        4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *        5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *        6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *        7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *        8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _pcts Array containing:
     *        0. penaltyPct Permyriad of min active tokens balance to be locked to each drafted jurors (‱ - 1/10,000)
     *        1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @param _roundParams Array containing params for rounds:
-    *        0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *        1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *        2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *        3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @param _appealCollateralParams Array containing params for appeal collateral:
     *        0. appealCollateralFactor Permyriad multiple of dispute fees required to appeal a preliminary ruling
     *        1. appealConfirmCollateralFactor Permyriad multiple of dispute fees required to confirm appeal
@@ -178,9 +178,9 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         uint64 _fromTermId,
         ERC20 _feeToken,
         uint256[3] calldata _fees,
-        uint64[5] calldata _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] calldata _roundParams,
         uint16[2] calldata _pcts,
-        uint64[4] calldata _roundParams,
         uint256[2] calldata _appealCollateralParams,
         uint256[3] calldata _jurorsParams
     )
@@ -193,9 +193,9 @@ contract Controller is IsContract, CourtClock, CourtConfig {
             _fromTermId,
             _feeToken,
             _fees,
-            _roundStateDurations,
-            _pcts,
+            _maxRulingOptions,
             _roundParams,
+            _pcts,
             _appealCollateralParams,
             _jurorsParams
         );
@@ -290,20 +290,20 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     *         0. jurorFee Amount of fee tokens that is paid per juror per dispute
     *         1. draftFee Amount of fee tokens per juror to cover the drafting cost
     *         2. settleFee Amount of fee tokens per juror to cover round settlement cost
-    * @return roundStateDurations Array containing the durations in terms of the different phases of a dispute:
+    * @return maxRulingOptions Max number of selectable outcomes for each dispute
+    * @return roundParams Array containing durations of phases of a dispute and other params for rounds:
     *         0. evidenceTerms Max submitting evidence period duration in terms
     *         1. commitTerms Commit period duration in terms
     *         2. revealTerms Reveal period duration in terms
     *         3. appealTerms Appeal period duration in terms
     *         4. appealConfirmationTerms Appeal confirmation period duration in terms
+    *         5. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
+    *         6. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
+    *         7. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
+    *         8. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return pcts Array containing:
     *         0. penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
     *         1. finalRoundReduction Permyriad of fee reduction for the last appeal round (‱ - 1/10,000)
-    * @return roundParams Array containing params for rounds:
-    *         0. firstRoundJurorsNumber Number of jurors to be drafted for the first round of disputes
-    *         1. appealStepFactor Increasing factor for the number of jurors of each round of a dispute
-    *         2. maxRegularAppealRounds Number of regular appeal rounds before the final round is triggered
-    *         3. finalRoundLockTerms Number of terms that a coherent juror in a final round is disallowed to withdraw (to prevent 51% attacks)
     * @return appealCollateralParams Array containing params for appeal collateral:
     *         0. appealCollateralFactor Multiple of dispute fees required to appeal a preliminary ruling
     *         1. appealConfirmCollateralFactor Multiple of dispute fees required to confirm appeal
@@ -316,9 +316,9 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         )
@@ -333,9 +333,9 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         returns (
             ERC20 feeToken,
             uint256[3] memory fees,
-            uint64[5] memory roundStateDurations,
+            uint8 maxRulingOptions,
+            uint64[9] memory roundParams,
             uint16[2] memory pcts,
-            uint64[4] memory roundParams,
             uint256[2] memory appealCollateralParams,
             uint256[3] memory jurorsParams
         )

--- a/contracts/disputes/DisputeManager.sol
+++ b/contracts/disputes/DisputeManager.sol
@@ -57,9 +57,6 @@ contract DisputeManager is ControlledRecoverable, ICRVotingOwner, IDisputeManage
     // Minimum possible rulings for a dispute
     uint8 internal constant MIN_RULING_OPTIONS = 2;
 
-    // Maximum possible rulings for a dispute, equal to minimum limit
-    uint8 internal constant MAX_RULING_OPTIONS = MIN_RULING_OPTIONS;
-
     // Precision factor used to improve rounding when computing weights for the final round
     uint256 internal constant FINAL_ROUND_WEIGHT_PRECISION = 1000;
 
@@ -191,7 +188,8 @@ contract DisputeManager is ControlledRecoverable, ICRVotingOwner, IDisputeManage
     */
     function createDispute(IArbitrable _subject, uint8 _possibleRulings, bytes calldata _metadata) external onlyController returns (uint256) {
         uint64 termId = _ensureCurrentTerm();
-        require(_possibleRulings >= MIN_RULING_OPTIONS && _possibleRulings <= MAX_RULING_OPTIONS, ERROR_INVALID_RULING_OPTIONS);
+        Config memory config = _getConfigAt(termId);
+        require(_possibleRulings >= MIN_RULING_OPTIONS && _possibleRulings <= config.disputes.maxRulingOptions, ERROR_INVALID_RULING_OPTIONS);
 
         // Create the dispute
         uint256 disputeId = disputes.length++;
@@ -200,7 +198,6 @@ contract DisputeManager is ControlledRecoverable, ICRVotingOwner, IDisputeManage
         dispute.possibleRulings = _possibleRulings;
         dispute.createTermId = termId;
 
-        Config memory config = _getConfigAt(termId);
         uint64 jurorsNumber = config.disputes.firstRoundJurorsNumber;
         uint64 draftTermId = termId.add(config.disputes.evidenceTerms);
         emit NewDispute(disputeId, _subject, draftTermId, jurorsNumber, _metadata);

--- a/contracts/feesUpdater/FeesUpdater.sol
+++ b/contracts/feesUpdater/FeesUpdater.sol
@@ -9,7 +9,7 @@ contract FeesUpdater {
     IPriceOracle public priceOracle;
     AragonCourt public court;
     address public courtStableToken;
-    uint256[3] public courtStableValueFees;
+    uint256[3] public courtStableValueFees; // [jurorFee, draftFee, settleFee]
 
     constructor(
         IPriceOracle _priceOracle,
@@ -51,7 +51,6 @@ contract FeesUpdater {
         convertedFees[0] = priceOracle.consult(courtStableToken, courtStableValueFees[0], address(feeToken));
         convertedFees[1] = priceOracle.consult(courtStableToken, courtStableValueFees[1], address(feeToken));
         convertedFees[2] = priceOracle.consult(courtStableToken, courtStableValueFees[2], address(feeToken));
-
 
         court.setConfig(currentTerm + 1, feeToken, convertedFees, maxRulingOptions, roundParams, pcts, appealCollateralParams,
             jurorsParams);

--- a/contracts/feesUpdater/FeesUpdater.sol
+++ b/contracts/feesUpdater/FeesUpdater.sol
@@ -40,9 +40,9 @@ contract FeesUpdater {
         // that is scheduled for a future term will be scheduled for the next term instead.
         uint64 latestPossibleTerm = uint64(-1);
         (ERC20 feeToken,,
-        uint64[5] memory roundStateDurations,
+        uint8 maxRulingOptions,
+        uint64[9] memory roundParams,
         uint16[2] memory pcts,
-        uint64[4] memory roundParams,
         uint256[2] memory appealCollateralParams,
         uint256[3] memory jurorsParams
         ) = court.getConfig(latestPossibleTerm);
@@ -52,7 +52,8 @@ contract FeesUpdater {
         convertedFees[1] = priceOracle.consult(courtStableToken, courtStableValueFees[1], address(feeToken));
         convertedFees[2] = priceOracle.consult(courtStableToken, courtStableValueFees[2], address(feeToken));
 
-        court.setConfig(currentTerm + 1, feeToken, convertedFees, roundStateDurations, pcts, roundParams,
-            appealCollateralParams, jurorsParams);
+
+        court.setConfig(currentTerm + 1, feeToken, convertedFees, maxRulingOptions, roundParams, pcts, appealCollateralParams,
+            jurorsParams);
     }
 }

--- a/contracts/test/court/AragonCourtMock.sol
+++ b/contracts/test/court/AragonCourtMock.sol
@@ -13,9 +13,9 @@ contract AragonCourtMock is AragonCourt, TimeHelpersMock {
         address[4] memory _governors,
         ERC20 _feeToken,
         uint256[3] memory _fees,
-        uint64[5] memory _roundStateDurations,
+        uint8 _maxRulingOptions,
+        uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
         uint256[2] memory _appealCollateralParams,
         uint256[3] memory _jurorsParams
     )
@@ -24,9 +24,9 @@ contract AragonCourtMock is AragonCourt, TimeHelpersMock {
             _governors,
             _feeToken,
             _fees,
-            _roundStateDurations,
-            _pcts,
+            _maxRulingOptions,
             _roundParams,
+            _pcts,
             _appealCollateralParams,
             _jurorsParams
         )

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@1hive/celeste",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Celeste Oracle",
   "author": "Aragon Association",
   "license": "GPL-3.0",
   "files": [
     "/abi",
     "/artifacts",
-    "/contracts"
+    "/contracts",
+    "/test"
   ],
   "scripts": {
     "compile": "buidler compile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1hive/celeste",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Celeste Oracle",
   "author": "Aragon Association",
   "license": "GPL-3.0",

--- a/test/court/controller/controller-config.js
+++ b/test/court/controller/controller-config.js
@@ -118,6 +118,14 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
         await assertRevert(courtHelper.deploy({ maxRegularAppealRounds: bn(11) }), CONFIG_ERRORS.INVALID_MAX_APPEAL_ROUNDS)
       })
 
+      it('cannot use max ruling options less than 2', async () => {
+        await assertRevert(courtHelper.deploy({ maxRulingOptions: bn(1) }), "CONF_RULING_OPTIONS_LESS_THAN_MIN")
+      })
+
+      it('cannot use max ruling options more than 252', async () => {
+        await assertRevert(courtHelper.deploy({ maxRulingOptions: bn(253) }), "CONF_RULING_OPTIONS_LESS_THAN_MIN")
+      })
+
       it('cannot use a adjudication round durations zero', async () => {
         await assertRevert(courtHelper.deploy({ evidenceTerms: bn(0) }), CONFIG_ERRORS.LARGE_ROUND_PHASE_DURATION)
         await assertRevert(courtHelper.deploy({ commitTerms: bn(0) }), CONFIG_ERRORS.LARGE_ROUND_PHASE_DURATION)

--- a/test/court/controller/controller-config.js
+++ b/test/court/controller/controller-config.js
@@ -123,7 +123,7 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
       })
 
       it('cannot use max ruling options more than 252', async () => {
-        await assertRevert(courtHelper.deploy({ maxRulingOptions: bn(253) }), "CONF_RULING_OPTIONS_LESS_THAN_MIN")
+        await assertRevert(courtHelper.deploy({ maxRulingOptions: bn(253) }), "CONF_RULING_OPTIONS_MORE_THAN_MAX")
       })
 
       it('cannot use a adjudication round durations zero', async () => {

--- a/test/court/controller/controller-config.js
+++ b/test/court/controller/controller-config.js
@@ -15,6 +15,7 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
   const jurorFee = bigExp(10, 18)
   const draftFee = bigExp(30, 18)
   const settleFee = bigExp(40, 18)
+  const maxRulingOptions = bn(2)
   const evidenceTerms = bn(1)
   const commitTerms = bn(1)
   const revealTerms = bn(2)
@@ -41,6 +42,7 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
       jurorFee,
       draftFee,
       settleFee,
+      maxRulingOptions,
       evidenceTerms,
       commitTerms,
       revealTerms,

--- a/test/disputes/disputes-settle-round.js
+++ b/test/disputes/disputes-settle-round.js
@@ -726,7 +726,7 @@ contract('DisputeManager', ([_, drafter, appealMaker, appealTaker, juror500, jur
 
                     afterEach('reactivate jurors and pass final round lock terms', async () => {
                       for (const { address, initialActiveBalance } of jurors) {
-                        const { jurorToken, jurorsRegistry } = courtHelper
+                        const { feeToken, jurorsRegistry } = courtHelper
                         const unlockedBalance = await jurorsRegistry.unlockedActiveBalanceOf(address)
 
                         if (unlockedBalance.gt(initialActiveBalance)) {
@@ -736,8 +736,8 @@ contract('DisputeManager', ([_, drafter, appealMaker, appealTaker, juror500, jur
 
                         if (unlockedBalance.lt(initialActiveBalance)) {
                           const amount = initialActiveBalance.sub(unlockedBalance)
-                          await jurorToken.generateTokens(address, amount)
-                          await jurorToken.approveAndCall(jurorsRegistry.address, amount, ACTIVATE_DATA, { from: address })
+                          await feeToken.generateTokens(address, amount)
+                          await feeToken.approveAndCall(jurorsRegistry.address, amount, ACTIVATE_DATA, { from: address })
                         }
                       }
 

--- a/test/feesUpdater/feesUpdater.js
+++ b/test/feesUpdater/feesUpdater.js
@@ -14,6 +14,7 @@ contract("FeesUpdater", ([_]) => {
   const jurorFee = bigExp(10, 18)
   const draftFee = bigExp(30, 18)
   const settleFee = bigExp(40, 18)
+  const maxRulingOptions = bn(2)
   const evidenceTerms = bn(1)
   const commitTerms = bn(1)
   const revealTerms = bn(2)
@@ -53,6 +54,7 @@ contract("FeesUpdater", ([_]) => {
       jurorFee,
       draftFee,
       settleFee,
+      maxRulingOptions,
       evidenceTerms,
       commitTerms,
       revealTerms,

--- a/test/helpers/utils/config.js
+++ b/test/helpers/utils/config.js
@@ -10,7 +10,7 @@ module.exports = artifacts => {
       jurorFee: config.jurorFee.add(bigExp(iteration * 10, 18)),
       draftFee: config.draftFee.add(bigExp(iteration * 10, 18)),
       settleFee: config.settleFee.add(bigExp(iteration * 10, 18)),
-      maxRulingOptions: config.maxRulingOptions,
+      maxRulingOptions: config.maxRulingOptions.add(bn(iteration)),
       evidenceTerms: config.evidenceTerms.add(bn(iteration)),
       commitTerms: config.commitTerms.add(bn(iteration)),
       revealTerms: config.revealTerms.add(bn(iteration)),

--- a/test/helpers/utils/config.js
+++ b/test/helpers/utils/config.js
@@ -10,6 +10,7 @@ module.exports = artifacts => {
       jurorFee: config.jurorFee.add(bigExp(iteration * 10, 18)),
       draftFee: config.draftFee.add(bigExp(iteration * 10, 18)),
       settleFee: config.settleFee.add(bigExp(iteration * 10, 18)),
+      maxRulingOptions: config.maxRulingOptions,
       evidenceTerms: config.evidenceTerms.add(bn(iteration)),
       commitTerms: config.commitTerms.add(bn(iteration)),
       revealTerms: config.revealTerms.add(bn(iteration)),
@@ -34,6 +35,7 @@ module.exports = artifacts => {
     assertBn(actualConfig.jurorFee, expectedConfig.jurorFee, 'juror fee does not match')
     assertBn(actualConfig.draftFee, expectedConfig.draftFee, 'draft fee does not match')
     assertBn(actualConfig.settleFee, expectedConfig.settleFee, 'settle fee does not match')
+    assertBn(actualConfig.maxRulingOptions, expectedConfig.maxRulingOptions, 'max ruling options does not match')
     assertBn(actualConfig.commitTerms, expectedConfig.commitTerms, 'commit terms number does not match')
     assertBn(actualConfig.revealTerms, expectedConfig.revealTerms, 'reveal terms number does not match')
     assertBn(actualConfig.appealTerms, expectedConfig.appealTerms, 'appeal terms number does not match')

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -38,6 +38,7 @@ const DEFAULTS = {
   firstTermStartTime:                 bn(NEXT_WEEK),   //  first term starts one week after mocked timestamp
   skippedDisputes:                    bn(0),           //  number of disputes to be skipped
   maxJurorsPerDraftBatch:             bn(10),          //  max number of jurors drafted per batch
+  maxRulingOptions:                   bn(2),           //  max number of selectable outcomes for jurors
   evidenceTerms:                      bn(4),           //  evidence period lasts 4 terms maximum
   commitTerms:                        bn(2),           //  vote commits last 2 terms
   revealTerms:                        bn(2),           //  vote reveals last 2 terms
@@ -72,23 +73,24 @@ module.exports = (web3, artifacts) => {
     }
 
     async getConfig(termId) {
-      const { feeToken, fees, roundStateDurations, pcts, roundParams, appealCollateralParams, jurorsParams } = await this.court.getConfig(termId)
+      const { feeToken, fees, maxRulingOptions, roundParams, pcts, appealCollateralParams, jurorsParams } = await this.court.getConfig(termId)
       return {
         feeToken: await this.artifacts.require('ERC20Mock').at(feeToken),
         jurorFee: fees[0],
         draftFee: fees[1],
         settleFee: fees[2],
-        evidenceTerms: roundStateDurations[0],
-        commitTerms: roundStateDurations[1],
-        revealTerms: roundStateDurations[2],
-        appealTerms: roundStateDurations[3],
-        appealConfirmTerms: roundStateDurations[4],
+        maxRulingOptions: maxRulingOptions,
+        evidenceTerms: roundParams[0],
+        commitTerms: roundParams[1],
+        revealTerms: roundParams[2],
+        appealTerms: roundParams[3],
+        appealConfirmTerms: roundParams[4],
         penaltyPct: pcts[0],
         finalRoundReduction: pcts[1],
-        firstRoundJurorsNumber: roundParams[0],
-        appealStepFactor: roundParams[1],
-        maxRegularAppealRounds: roundParams[2],
-        finalRoundLockTerms: roundParams[3],
+        firstRoundJurorsNumber: roundParams[5],
+        appealStepFactor: roundParams[6],
+        maxRegularAppealRounds: roundParams[7],
+        finalRoundLockTerms: roundParams[8],
         appealCollateralFactor: appealCollateralParams[0],
         appealConfirmCollateralFactor: appealCollateralParams[1],
         minActiveBalance: jurorsParams[0],
@@ -356,9 +358,9 @@ module.exports = (web3, artifacts) => {
       const {
         feeToken,
         jurorFee, draftFee, settleFee,
-        evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms,
+        maxRulingOptions,
+        evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms, firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms,
         penaltyPct, finalRoundReduction,
-        firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms,
         appealCollateralFactor, appealConfirmCollateralFactor,
         minActiveBalance, minMaxPctTotalSupply, maxMaxPctTotalSupply
       } = newConfig
@@ -367,9 +369,9 @@ module.exports = (web3, artifacts) => {
         termId,
         feeToken.address,
         [jurorFee, draftFee, settleFee],
-        [evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms],
+        maxRulingOptions,
+        [evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms, firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms],
         [penaltyPct, finalRoundReduction],
-        [firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms],
         [appealCollateralFactor, appealConfirmCollateralFactor],
         [minActiveBalance, minMaxPctTotalSupply, maxMaxPctTotalSupply],
         txParams

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -38,7 +38,7 @@ const DEFAULTS = {
   firstTermStartTime:                 bn(NEXT_WEEK),   //  first term starts one week after mocked timestamp
   skippedDisputes:                    bn(0),           //  number of disputes to be skipped
   maxJurorsPerDraftBatch:             bn(10),          //  max number of jurors drafted per batch
-  maxRulingOptions:                   bn(3),           //  max number of selectable outcomes for jurors
+  maxRulingOptions:                   bn(2),           //  max number of selectable outcomes for jurors
   evidenceTerms:                      bn(4),           //  evidence period lasts 4 terms maximum
   commitTerms:                        bn(2),           //  vote commits last 2 terms
   revealTerms:                        bn(2),           //  vote reveals last 2 terms

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -38,7 +38,7 @@ const DEFAULTS = {
   firstTermStartTime:                 bn(NEXT_WEEK),   //  first term starts one week after mocked timestamp
   skippedDisputes:                    bn(0),           //  number of disputes to be skipped
   maxJurorsPerDraftBatch:             bn(10),          //  max number of jurors drafted per batch
-  maxRulingOptions:                   bn(2),           //  max number of selectable outcomes for jurors
+  maxRulingOptions:                   bn(3),           //  max number of selectable outcomes for jurors
   evidenceTerms:                      bn(4),           //  evidence period lasts 4 terms maximum
   commitTerms:                        bn(2),           //  vote commits last 2 terms
   revealTerms:                        bn(2),           //  vote reveals last 2 terms

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -390,9 +390,9 @@ module.exports = (web3, artifacts) => {
         [this.fundsGovernor, this.configGovernor, this.feesUpdater, this.modulesGovernor],
         this.feeToken.address,
         [this.jurorFee, this.draftFee, this.settleFee],
-        [this.evidenceTerms, this.commitTerms, this.revealTerms, this.appealTerms, this.appealConfirmTerms],
+        this.maxRulingOptions,
+        [this.evidenceTerms, this.commitTerms, this.revealTerms, this.appealTerms, this.appealConfirmTerms, this.firstRoundJurorsNumber, this.appealStepFactor, this.maxRegularAppealRounds, this.finalRoundLockTerms],
         [this.penaltyPct, this.finalRoundReduction],
-        [this.firstRoundJurorsNumber, this.appealStepFactor, this.maxRegularAppealRounds, this.finalRoundLockTerms],
         [this.appealCollateralFactor, this.appealConfirmCollateralFactor],
         [this.minActiveBalance, this.minMaxPctTotalSupply, this.maxMaxPctTotalSupply]
       )


### PR DESCRIPTION
Made the number of options a dispute can be over configurable. It was previously hardcoded to 2.

Had to merge a couple of the config arrays to avoid stack too deep error.