### PR TITLE
Optional hardcoded fee token total supply

### DIFF
--- a/contracts/court/Celeste.sol
+++ b/contracts/court/Celeste.sol
@@ -50,6 +50,7 @@ contract Celeste is Controller, IArbitrator {
     *        0. minActiveBalance Minimum amount of juror tokens that can be activated
     *        1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *        2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *        3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     constructor(
         uint64[2] memory _termParams,
@@ -60,7 +61,7 @@ contract Celeste is Controller, IArbitrator {
         uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
         uint256[2] memory _appealCollateralParams,
-        uint256[3] memory _jurorsParams
+        uint256[4] memory _jurorsParams
     )
         public
         Controller(

--- a/contracts/court/clock/CourtClock.sol
+++ b/contracts/court/clock/CourtClock.sol
@@ -221,7 +221,7 @@ contract CourtClock is IClock, TimeHelpers {
             // already assumed to fit in uint64.
             Term storage previousTerm = terms[currentTermId++];
             Term storage currentTerm = terms[currentTermId];
-            (ERC20 feeToken,,,,,,) = _getConfig(currentTermId);
+            (ERC20 feeToken,,,,,, uint256[4] memory jurorsParams) = _getConfig(currentTermId);
             _onTermTransitioned(currentTermId);
 
             // Set the start time of the new term. Note that we are using a constant term duration value to guarantee
@@ -232,7 +232,9 @@ contract CourtClock is IClock, TimeHelpers {
             // block number that is set once the term has started. Note that this information could not be known beforehand.
             currentTerm.randomnessBN = blockNumber + 1;
 
-            currentTerm.celesteTokenTotalSupply = feeToken.totalSupply();
+            // We check if the feeTokenTotalSupply is set, which means this networks feeToken doesn't have an accurate
+            // totalSupply so we will use the hardcoded value
+            currentTerm.celesteTokenTotalSupply = jurorsParams[3] > 0 ? jurorsParams[3] : feeToken.totalSupply();
         }
 
         termId = currentTermId;
@@ -337,6 +339,8 @@ contract CourtClock is IClock, TimeHelpers {
     *         0. minActiveBalance Minimum amount of juror tokens that can be activated
     *         1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *         2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *         3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
+
     */
     function _getConfig(uint64 _termId) internal view returns (
         ERC20 feeToken,
@@ -345,6 +349,6 @@ contract CourtClock is IClock, TimeHelpers {
         uint64[9] memory roundParams,
         uint16[2] memory pcts,
         uint256[2] memory appealCollateralParams,
-        uint256[3] memory jurorsParams
+        uint256[4] memory jurorsParams
     );
 }

--- a/contracts/court/config/ConfigConsumer.sol
+++ b/contracts/court/config/ConfigConsumer.sol
@@ -25,7 +25,7 @@ contract ConfigConsumer is CourtConfigData {
         uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
         uint256[2] memory _appealCollateralParams,
-        uint256[3] memory _jurorsParams) = _courtConfig().getConfig(_termId);
+        uint256[4] memory _jurorsParams) = _courtConfig().getConfig(_termId);
 
         Config memory config;
 
@@ -56,7 +56,8 @@ contract ConfigConsumer is CourtConfigData {
         config.jurors = JurorsConfig({
             minActiveBalance: _jurorsParams[0],
             minMaxPctTotalSupply: _jurorsParams[1],
-            maxMaxPctTotalSupply: _jurorsParams[2]
+            maxMaxPctTotalSupply: _jurorsParams[2],
+            feeTokenTotalSupply: _jurorsParams[3]
         });
 
         return config;

--- a/contracts/court/config/CourtConfig.sol
+++ b/contracts/court/config/CourtConfig.sol
@@ -76,6 +76,7 @@ contract CourtConfig is IConfig, CourtConfigData {
     *        0. minActiveBalance Minimum amount of juror tokens that can be activated
     *        1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *        2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *        3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     constructor(
         ERC20 _feeToken,
@@ -84,7 +85,7 @@ contract CourtConfig is IConfig, CourtConfigData {
         uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
         uint256[2] memory _appealCollateralParams,
-        uint256[3] memory _jurorsParams
+        uint256[4] memory _jurorsParams
     )
         public
     {
@@ -141,6 +142,7 @@ contract CourtConfig is IConfig, CourtConfigData {
     *         0. minActiveBalance Minimum amount of juror tokens that can be activated
     *         1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *         2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *         3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     function getConfig(uint64 _termId) external view
         returns (
@@ -150,7 +152,7 @@ contract CourtConfig is IConfig, CourtConfigData {
             uint64[9] memory roundParams,
             uint16[2] memory pcts,
             uint256[2] memory appealCollateralParams,
-            uint256[3] memory jurorsParams
+            uint256[4] memory jurorsParams
         );
 
     /**
@@ -229,6 +231,7 @@ contract CourtConfig is IConfig, CourtConfigData {
     *        0. minActiveBalance Minimum amount of juror tokens that can be activated
     *        1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *        2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *        3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     function _setConfig(
         uint64 _termId,
@@ -239,7 +242,7 @@ contract CourtConfig is IConfig, CourtConfigData {
         uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
         uint256[2] memory _appealCollateralParams,
-        uint256[3] memory _jurorsParams
+        uint256[4] memory _jurorsParams
     )
         internal
     {
@@ -321,7 +324,8 @@ contract CourtConfig is IConfig, CourtConfigData {
         config.jurors = JurorsConfig({
             minActiveBalance: _jurorsParams[0],
             minMaxPctTotalSupply: _jurorsParams[1],
-            maxMaxPctTotalSupply: _jurorsParams[2]
+            maxMaxPctTotalSupply: _jurorsParams[2],
+            feeTokenTotalSupply: _jurorsParams[3]
         });
 
         configIdByTerm[_fromTermId] = courtConfigId;
@@ -360,6 +364,7 @@ contract CourtConfig is IConfig, CourtConfigData {
     *         0. minActiveBalance Minimum amount of juror tokens that can be activated
     *         1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *         2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *         3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     function _getConfigAt(uint64 _termId, uint64 _lastEnsuredTermId) internal view
         returns (
@@ -369,7 +374,7 @@ contract CourtConfig is IConfig, CourtConfigData {
             uint64[9] memory roundParams,
             uint16[2] memory pcts,
             uint256[2] memory appealCollateralParams,
-            uint256[3] memory jurorsParams
+            uint256[4] memory jurorsParams
         )
     {
         Config storage config = _getConfigFor(_termId, _lastEnsuredTermId);
@@ -398,7 +403,8 @@ contract CourtConfig is IConfig, CourtConfigData {
         jurorsParams = [
             jurorsConfig.minActiveBalance,
             jurorsConfig.minMaxPctTotalSupply,
-            jurorsConfig.maxMaxPctTotalSupply
+            jurorsConfig.maxMaxPctTotalSupply,
+            jurorsConfig.feeTokenTotalSupply
         ];
     }
 

--- a/contracts/court/config/CourtConfigData.sol
+++ b/contracts/court/config/CourtConfigData.sol
@@ -39,6 +39,7 @@ contract CourtConfigData {
         uint256 minActiveBalance;               // Minimum amount of tokens jurors have to activate to participate in the Court
         uint256 minMaxPctTotalSupply;           // Minimum max percent of the total supply a juror can activate, applied for total supply active stake
         uint256 maxMaxPctTotalSupply;           // Maximum max percent of the total supply a juror can activate, applied for 0 active stake
+        uint256 feeTokenTotalSupply;            // Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     }
 
     struct DraftConfig {

--- a/contracts/court/config/IConfig.sol
+++ b/contracts/court/config/IConfig.sol
@@ -34,6 +34,7 @@ interface IConfig {
     *         0. minActiveBalance Minimum amount of juror tokens that can be activated
     *         1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *         2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *         3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     function getConfig(uint64 _termId) external view
         returns (
@@ -43,7 +44,7 @@ interface IConfig {
             uint64[9] memory roundParams,
             uint16[2] memory pcts,
             uint256[2] memory appealCollateralParams,
-            uint256[3] memory jurorsParams
+            uint256[4] memory jurorsParams
         );
 
     /**

--- a/contracts/court/controller/Controller.sol
+++ b/contracts/court/controller/Controller.sol
@@ -122,6 +122,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     *        0. minActiveBalance Minimum amount of juror tokens that can be activated
     *        1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *        2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *        3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     constructor(
         uint64[2] memory _termParams,
@@ -132,7 +133,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
         uint256[2] memory _appealCollateralParams,
-        uint256[3] memory _jurorsParams
+        uint256[4] memory _jurorsParams
     )
         public
         CourtClock(_termParams, _feeToken)
@@ -173,6 +174,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     *        0. minActiveBalance Minimum amount of juror tokens that can be activated
     *        1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
     *        2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *        3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     function setConfig(
         uint64 _fromTermId,
@@ -182,7 +184,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
         uint64[9] calldata _roundParams,
         uint16[2] calldata _pcts,
         uint256[2] calldata _appealCollateralParams,
-        uint256[3] calldata _jurorsParams
+        uint256[4] calldata _jurorsParams
     )
         external
         onlyConfigGovernorOrFeesUpdater
@@ -310,7 +312,8 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     * @return jurorsParams Array containing params for juror registry:
     *         0. minActiveBalance Minimum amount of juror tokens that can be activated
     *         1. minMaxPctTotalSupply The min max percent of the total supply a juror can activate, applied for total supply active stake
-    *         2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake
+    *         2. maxMaxPctTotalSupply The max max percent of the total supply a juror can activate, applied for 0 active stake\
+    *         3. feeTokenTotalSupply Set for networks that don't have access to the fee token's total supply, set to 0 for networks that do
     */
     function getConfig(uint64 _termId) external view
         returns (
@@ -320,7 +323,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
             uint64[9] memory roundParams,
             uint16[2] memory pcts,
             uint256[2] memory appealCollateralParams,
-            uint256[3] memory jurorsParams
+            uint256[4] memory jurorsParams
         )
     {
         return _getConfig(_termId);
@@ -337,7 +340,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
             uint64[9] memory roundParams,
             uint16[2] memory pcts,
             uint256[2] memory appealCollateralParams,
-            uint256[3] memory jurorsParams
+            uint256[4] memory jurorsParams
         )
     {
         uint64 lastEnsuredTermId = _lastEnsuredTermId();

--- a/contracts/feesUpdater/FeesUpdater.sol
+++ b/contracts/feesUpdater/FeesUpdater.sol
@@ -44,7 +44,7 @@ contract FeesUpdater {
         uint64[9] memory roundParams,
         uint16[2] memory pcts,
         uint256[2] memory appealCollateralParams,
-        uint256[3] memory jurorsParams
+        uint256[4] memory jurorsParams
         ) = court.getConfig(latestPossibleTerm);
 
         uint256[3] memory convertedFees;

--- a/contracts/test/court/CelesteMock.sol
+++ b/contracts/test/court/CelesteMock.sol
@@ -17,7 +17,7 @@ contract CelesteMock is Celeste, TimeHelpersMock {
         uint64[9] memory _roundParams,
         uint16[2] memory _pcts,
         uint256[2] memory _appealCollateralParams,
-        uint256[3] memory _jurorsParams
+        uint256[4] memory _jurorsParams
     )
         Celeste(
             _termParams,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1hive/celeste",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Celeste Oracle",
   "author": "1Hive",
   "license": "GPL-3.0",

--- a/test/court/controller/controller-config.js
+++ b/test/court/controller/controller-config.js
@@ -32,6 +32,7 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
   const minActiveBalance = bigExp(200, 18)
   const minMaxPctTotalSupply = bigExp(2, 15) // 0.2%
   const maxMaxPctTotalSupply = bigExp(2, 16) // 2%
+  const feeTokenTotalSupply = bn(0)
 
   const checkConfig = async (termId, expectedConfig) => assertConfig(await courtHelper.getConfig(termId), expectedConfig)
 
@@ -58,7 +59,8 @@ contract('Controller', ([_, configGovernor, feesUpdater, someone, drafter, appea
       appealConfirmCollateralFactor,
       minActiveBalance,
       minMaxPctTotalSupply,
-      maxMaxPctTotalSupply
+      maxMaxPctTotalSupply,
+      feeTokenTotalSupply
     }
   })
 

--- a/test/helpers/utils/config.js
+++ b/test/helpers/utils/config.js
@@ -27,6 +27,7 @@ module.exports = artifacts => {
       minActiveBalance: config.minActiveBalance.add(bigExp(iteration * 100, 18)),
       minMaxPctTotalSupply: config.minMaxPctTotalSupply.add(bigExp(1, 15)),
       maxMaxPctTotalSupply: bigExp(100, 16),
+      feeTokenTotalSupply: 0
     }
   }
 
@@ -51,6 +52,7 @@ module.exports = artifacts => {
     assertBn(actualConfig.minActiveBalance, expectedConfig.minActiveBalance, 'min active balance does not match')
     assertBn(actualConfig.minMaxPctTotalSupply, expectedConfig.minMaxPctTotalSupply, 'min max pct total supply active balance does not match')
     assertBn(actualConfig.maxMaxPctTotalSupply, expectedConfig.maxMaxPctTotalSupply, 'max max pct total supply active balance does not match')
+    assertBn(actualConfig.feeTokenTotalSupply, expectedConfig.feeTokenTotalSupply, 'fee token total supply does not match')
   }
 
   return {

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -58,6 +58,7 @@ const DEFAULTS = {
   minActiveBalance:                   bigExp(100, 18), //  100 ANJ is the minimum balance jurors must activate to participate in the Court
   minMaxPctTotalSupply:               bigExp(1, 15),   //  0.1% of the current total supply is the max a juror can activate when the total supply stake is activated
   maxMaxPctTotalSupply:               bigExp(1, 16),   //  1% of the current total supply is the max a juror can activate when 0 stake is activated
+  feeTokenTotalSupply:                bn(0),              //  0 means the total supply used will be the real fee token total supply
   finalRoundWeightPrecision:          bn(1000),           //  use to improve division rounding for final round maths
   subscriptionPeriodDuration:         bn(10),             //  each subscription period lasts 10 terms
   periodPercentageYield:              bigExp(2, 16)    //  each subscription period pays out 2% of total active stake
@@ -96,7 +97,8 @@ module.exports = (web3, artifacts) => {
         appealConfirmCollateralFactor: appealCollateralParams[1],
         minActiveBalance: jurorsParams[0],
         minMaxPctTotalSupply: jurorsParams[1],
-        maxMaxPctTotalSupply: jurorsParams[2]
+        maxMaxPctTotalSupply: jurorsParams[2],
+        feeTokenTotalSupply: jurorsParams[3]
       }
     }
 
@@ -363,7 +365,7 @@ module.exports = (web3, artifacts) => {
         evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms, firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms,
         penaltyPct, finalRoundReduction,
         appealCollateralFactor, appealConfirmCollateralFactor,
-        minActiveBalance, minMaxPctTotalSupply, maxMaxPctTotalSupply
+        minActiveBalance, minMaxPctTotalSupply, maxMaxPctTotalSupply, feeTokenTotalSupply
       } = newConfig
 
       return this.court.setConfig(
@@ -374,7 +376,7 @@ module.exports = (web3, artifacts) => {
         [evidenceTerms, commitTerms, revealTerms, appealTerms, appealConfirmTerms, firstRoundJurorsNumber, appealStepFactor, maxRegularAppealRounds, finalRoundLockTerms],
         [penaltyPct, finalRoundReduction],
         [appealCollateralFactor, appealConfirmCollateralFactor],
-        [minActiveBalance, minMaxPctTotalSupply, maxMaxPctTotalSupply],
+        [minActiveBalance, minMaxPctTotalSupply, maxMaxPctTotalSupply, feeTokenTotalSupply],
         txParams
       )
     }
@@ -388,7 +390,7 @@ module.exports = (web3, artifacts) => {
       if (!this.modulesGovernor) this.modulesGovernor = await this._getAccount(0)
       if (!this.feeToken) this.feeToken = await this.artifacts.require('ERC20Mock').new('Court Token', 'CTT', 18)
 
-      this.court = await this.artifacts.require('AragonCourtMock').new(
+      this.court = await this.artifacts.require('CelesteMock').new(
         [this.termDuration, this.firstTermStartTime],
         [this.fundsGovernor, this.configGovernor, this.feesUpdater, this.modulesGovernor],
         this.feeToken.address,
@@ -397,7 +399,7 @@ module.exports = (web3, artifacts) => {
         [this.evidenceTerms, this.commitTerms, this.revealTerms, this.appealTerms, this.appealConfirmTerms, this.firstRoundJurorsNumber, this.appealStepFactor, this.maxRegularAppealRounds, this.finalRoundLockTerms],
         [this.penaltyPct, this.finalRoundReduction],
         [this.appealCollateralFactor, this.appealConfirmCollateralFactor],
-        [this.minActiveBalance, this.minMaxPctTotalSupply, this.maxMaxPctTotalSupply]
+        [this.minActiveBalance, this.minMaxPctTotalSupply, this.maxMaxPctTotalSupply, this.feeTokenTotalSupply]
       )
 
       if (!this.disputeManager) this.disputeManager = await this.artifacts.require('DisputeManager').new(this.court.address, this.maxJurorsPerDraftBatch, this.skippedDisputes)


### PR DESCRIPTION
Added optional configuration of the fee token total supply for use on networks where the fee token's total supply is not accurate (eg any bridged networks). It is saved at every heartbeat for use in the JurorsRegistry.

Including tests.